### PR TITLE
Add GetServiceEndpoint method

### DIFF
--- a/errors/codes.go
+++ b/errors/codes.go
@@ -35,15 +35,16 @@ var (
 
 	// Meshkit specific codes
 	// Range 10200 to 10299
-	ErrSmiInit       = "kit_10200"
-	ErrInstallSmi    = "kit_10201"
-	ErrConnectSmi    = "kit_10202"
-	ErrRunSmi        = "kit_10203"
-	ErrDeleteSmi     = "kit_10204"
-	ErrUnmarshal     = "kit_10205"
-	ErrMarshal       = "kit_10205"
-	ErrGetBool       = "kit_10205"
-	ErrApplyManifest = "kit_10206"
+	ErrSmiInit          = "kit_10200"
+	ErrInstallSmi       = "kit_10201"
+	ErrConnectSmi       = "kit_10202"
+	ErrRunSmi           = "kit_10203"
+	ErrDeleteSmi        = "kit_10204"
+	ErrUnmarshal        = "kit_10205"
+	ErrMarshal          = "kit_10205"
+	ErrGetBool          = "kit_10205"
+	ErrApplyManifest    = "kit_10206"
+	ErrServiceDiscovery = "kit_10207"
 
 	// Istio Service mesh specific codes
 	// Range 11000 to 11099

--- a/utils/kubernetes/error.go
+++ b/utils/kubernetes/error.go
@@ -5,3 +5,8 @@ import "github.com/layer5io/meshkit/errors"
 func ErrApplyManifest(err error) error {
 	return errors.NewDefault(errors.ErrApplyManifest, "Error Applying manifest: "+err.Error())
 }
+
+// ErrServiceDiscovery returns an error of type "ErrServiceDiscovery" along with the passed error
+func ErrServiceDiscovery(err error) error {
+	return errors.NewDefault(errors.ErrServiceDiscovery, "Error Discovering service: "+err.Error())
+}

--- a/utils/kubernetes/kubernetes.go
+++ b/utils/kubernetes/kubernetes.go
@@ -27,18 +27,7 @@ func New(clientset kubernetes.Interface, cfg rest.Config) (*Config, error) {
 func (cfg *Config) GetServiceEndpoint(ctx context.Context, svcName, namespace string) (*utils.Endpoint, error) {
 	svc, err := cfg.Clientset.CoreV1().Services(namespace).Get(ctx, svcName, v1.GetOptions{})
 	if err != nil {
-		return nil, errors.New(
-			errors.ErrServiceDiscovery,
-			errors.None,
-			[]string{"Error finding the service" + err.Error()},
-			errors.NoneString,
-			[]string{
-				"incorrect service name",
-				"incorrect namespace",
-				"service does not exist",
-			},
-			errors.NoneString,
-		)
+		return nil, errors.NewDefault(errors.ErrServiceDiscovery, "Error finding the service"+err.Error())
 	}
 
 	// Try loadbalancer endpoint

--- a/utils/kubernetes/kubernetes.go
+++ b/utils/kubernetes/kubernetes.go
@@ -1,6 +1,12 @@
 package kubernetes
 
 import (
+	"context"
+
+	"github.com/layer5io/meshkit/errors"
+	"github.com/layer5io/meshkit/utils"
+	coreV1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -15,4 +21,113 @@ func New(clientset kubernetes.Interface, cfg rest.Config) (*Config, error) {
 		Clientset:  clientset,
 		RestConfig: cfg,
 	}, nil
+}
+
+// GetServiceEndpoint returns the endpoint for the given service
+func (cfg *Config) GetServiceEndpoint(ctx context.Context, svcName, namespace string) (*utils.Endpoint, error) {
+	svc, err := cfg.Clientset.CoreV1().Services(namespace).Get(ctx, svcName, v1.GetOptions{})
+	if err != nil {
+		return nil, errors.New(
+			errors.ErrServiceDiscovery,
+			errors.None,
+			[]string{"Error finding the service" + err.Error()},
+			errors.NoneString,
+			[]string{
+				"incorrect service name",
+				"incorrect namespace",
+				"service does not exist",
+			},
+			errors.NoneString,
+		)
+	}
+
+	// Try loadbalancer endpoint
+	if endpoint := extractLoadBalancerEndpoint(svc); endpoint != nil {
+		return endpoint, nil
+	}
+
+	// Try nodeport endpoint
+	nodes, err := cfg.Clientset.CoreV1().Nodes().List(ctx, v1.ListOptions{})
+	if err != nil {
+		return nil, errors.NewDefault(errors.ErrServiceDiscovery, "Error getting the cluster nodes"+err.Error())
+	}
+	if endpoint := extractNodePortEndpoint(svc, nodes); endpoint != nil {
+		return endpoint, nil
+	}
+
+	// Try clusterip endpoint
+	if endpoint := extractClusterIPEndpoint(svc); endpoint != nil {
+		return endpoint, nil
+	}
+
+	return nil, err
+}
+
+// extractLoadBalancerEndpoint extracts loadbalancer based endpoint, if any.
+// It returns the nil if no valid endpoint is extracted
+func extractLoadBalancerEndpoint(svc *coreV1.Service) *utils.Endpoint {
+	ports := svc.Spec.Ports
+	ingresses := svc.Status.LoadBalancer.Ingress
+
+	for _, ingress := range ingresses {
+		var address string
+		if ingress.Hostname != "" && ingress.Hostname != "None" {
+			address = ingress.Hostname
+		} else if ingress.IP != "" {
+			address = ingress.IP
+		} else {
+			// If no valid ip address and hostname is found
+			// then move on to the next ingress
+			continue
+		}
+
+		for _, port := range ports {
+			return &utils.Endpoint{
+				Name:    svc.GetName(),
+				Address: address,
+				Port:    port.Port,
+			}
+		}
+	}
+
+	return nil
+}
+
+// extractNodePortEndpoint extracts nodeport based endpoint, if any.
+// It returns the nil if no valid endpoint is extracted
+func extractNodePortEndpoint(svc *coreV1.Service, nl *coreV1.NodeList) *utils.Endpoint {
+	ports := svc.Spec.Ports
+
+	for _, node := range nl.Items {
+		for _, addressData := range node.Status.Addresses {
+			if addressData.Type == "internalIP" {
+				address := addressData.Address
+
+				for _, port := range ports {
+					return &utils.Endpoint{
+						Name:    svc.GetName(),
+						Address: address,
+						Port:    port.Port,
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// extractClusterIPEndpoint extracts clusterIP based endpoint, if any.
+// It returns the nil if no valid endpoint is extracted
+func extractClusterIPEndpoint(svc *coreV1.Service) *utils.Endpoint {
+	ports := svc.Spec.Ports
+	clusterIP := svc.Spec.ClusterIP
+
+	for _, port := range ports {
+		return &utils.Endpoint{
+			Name:    svc.GetName(),
+			Address: clusterIP,
+			Port:    port.Port,
+		}
+	}
+	return nil
 }

--- a/utils/kubernetes/kubernetes.go
+++ b/utils/kubernetes/kubernetes.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"context"
 
-	"github.com/layer5io/meshkit/errors"
 	"github.com/layer5io/meshkit/utils"
 	coreV1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,7 +26,7 @@ func New(clientset kubernetes.Interface, cfg rest.Config) (*Config, error) {
 func (cfg *Config) GetServiceEndpoint(ctx context.Context, svcName, namespace string) (*utils.Endpoint, error) {
 	svc, err := cfg.Clientset.CoreV1().Services(namespace).Get(ctx, svcName, v1.GetOptions{})
 	if err != nil {
-		return nil, errors.NewDefault(errors.ErrServiceDiscovery, "Error finding the service"+err.Error())
+		return nil, ErrServiceDiscovery(err)
 	}
 
 	// Try loadbalancer endpoint
@@ -38,7 +37,7 @@ func (cfg *Config) GetServiceEndpoint(ctx context.Context, svcName, namespace st
 	// Try nodeport endpoint
 	nodes, err := cfg.Clientset.CoreV1().Nodes().List(ctx, v1.ListOptions{})
 	if err != nil {
-		return nil, errors.NewDefault(errors.ErrServiceDiscovery, "Error getting the cluster nodes"+err.Error())
+		return nil, ErrServiceDiscovery(err)
 	}
 	if endpoint := extractNodePortEndpoint(svc, nodes); endpoint != nil {
 		return endpoint, nil

--- a/utils/kubernetes/kubernetes.go
+++ b/utils/kubernetes/kubernetes.go
@@ -100,14 +100,17 @@ func extractNodePortEndpoint(svc *coreV1.Service, nl *coreV1.NodeList) *utils.En
 
 	for _, node := range nl.Items {
 		for _, addressData := range node.Status.Addresses {
-			if addressData.Type == "internalIP" {
+			if addressData.Type == "InternalIP" {
 				address := addressData.Address
 
 				for _, port := range ports {
-					return &utils.Endpoint{
-						Name:    svc.GetName(),
-						Address: address,
-						Port:    port.Port,
+					// nodeport 0 is an invalid nodeport
+					if port.NodePort != 0 {
+						return &utils.Endpoint{
+							Name:    svc.GetName(),
+							Address: address,
+							Port:    port.NodePort,
+						}
 					}
 				}
 			}

--- a/utils/network.go
+++ b/utils/network.go
@@ -6,6 +6,13 @@ import (
 	"time"
 )
 
+// Endpoint represents the structure for an endpoint
+type Endpoint struct {
+	Name    string
+	Address string
+	Port    int32
+}
+
 func TcpCheck(ip string, port int32) bool {
 	timeout := 5 * time.Second
 	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", ip, port), timeout)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/user"
+	"path"
 	"runtime"
 	"strconv"
 	"strings"
@@ -82,4 +83,25 @@ func DownloadFile(filepath string, url string) error {
 func GetHome() string {
 	usr, _ := user.Current()
 	return usr.HomeDir
+}
+
+// CreateFile creates a file with the given content on the given location with
+// the given filename
+func CreateFile(contents []byte, filename string, location string) error {
+	// Create file in -rw-r--r-- mode
+	fd, err := os.OpenFile(path.Join(location, filename), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+
+	if _, err = fd.Write(contents); err != nil {
+		fd.Close()
+		return err
+	}
+
+	if err = fd.Close(); err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
**Description**

This PR adds:
1. CreateFile utility function
2. GetServiceEndpoint method for finding endpoints for the given service in a namespace

**Notes for Reviewers**
As discussed with @kumarabd, the current approach first looks for a loadbalancer endpoint, fallsback to nodeport and then to clusterip endpoint. However, we can look at `spec.type` which does appear to indicate the type of the endpoint, can we use that instead of falling back?

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
