### PR TITLE
remove default namespace and namespace overrides

### DIFF
--- a/utils/kubernetes/apply-manifest.go
+++ b/utils/kubernetes/apply-manifest.go
@@ -31,7 +31,6 @@ type ApplyOptions struct {
 // If the the namespace does not exists, it will be created.
 func (client *Client) ApplyManifest(contents []byte, recvOptions ApplyOptions) error {
 	manifests := strings.Split(string(contents), "\n---\n")
-	manifests = manifests[1:]
 	if len(manifests) > 0 && manifests[len(manifests)-1] == "\n" {
 		manifests = manifests[:len(manifests)-1]
 	}


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

**Description**
1. This PR removes the namespace overrides. Now it falls back to namespace specified in the manifest if the ApplyOptions has no custom namespace specified. 
2. The ApplyManifest function no longer fails when namespace creation fails due to invalid namespace name (empty string), which may happen for api-resources which are not namespaced.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
