### PR TITLE
Add expose function

### DIFF
--- a/utils/kubernetes/expose/error.go
+++ b/utils/kubernetes/expose/error.go
@@ -8,40 +8,40 @@ import (
 
 var (
 	// ErrGettingResourceCode is generated when there is an error getting the kubernetes resource
-	ErrGettingResourceCode = "linkerd_test_code"
+	ErrGettingResourceCode = "meshkit_test_code"
 
 	// ErrTraverserCode is a collection of errors generated during traversing the resources
-	ErrTraverserCode = "linkerd_test_code"
+	ErrTraverserCode = "meshkit_test_code"
 
 	// ErrResourceCannotBeExposedCode is generated when the given resource cannot be exposed
-	ErrResourceCannotBeExposedCode = "linkerd_test_code"
+	ErrResourceCannotBeExposedCode = "meshkit_test_code"
 
 	// ErrSelectorBasedMapCode is generated when the given resource's selectors can't
 	// be parsed to a map
-	ErrSelectorBasedMapCode = "linkerd_test_code"
+	ErrSelectorBasedMapCode = "meshkit_test_code"
 
 	// ErrProtocolBasedMapCode is generated when the given resource's protocol can't
 	// be parsed to a map
-	ErrProtocolBasedMapCode = "linkerd_test_code"
+	ErrProtocolBasedMapCode = "meshkit_test_code"
 
 	// ErrLableBasedMapCode is generated when the given resource's protocol can't
 	// be parsed to a map
-	ErrLableBasedMapCode = "linkerd_test_code"
+	ErrLableBasedMapCode = "meshkit_test_code"
 
 	// ErrPortParsingCode is generated when the given resource's ports can't
 	// be parsed to a slice
-	ErrPortParsingCode = "linkerd_test_code"
+	ErrPortParsingCode = "meshkit_test_code"
 
 	// ErrGenerateServiceCode is generated when a service cannot be generated
 	// for the given resource
-	ErrGenerateServiceCode = "linkerd_test_code"
+	ErrGenerateServiceCode = "meshkit_test_code"
 
 	// ErrConstructingRestHelperCode is generated when a rest helper cannot be generated
 	// for the generated service
-	ErrConstructingRestHelperCode = "linkerd_test_code"
+	ErrConstructingRestHelperCode = "meshkit_test_code"
 
 	// ErrCreatingServiceCode is generated when there is an error deploying the service
-	ErrCreatingServiceCode = "linkerd_test_code"
+	ErrCreatingServiceCode = "meshkit_test_code"
 )
 
 // ErrGettingResource is the error when there is an error getting the kubernetes resource

--- a/utils/kubernetes/expose/error.go
+++ b/utils/kubernetes/expose/error.go
@@ -54,49 +54,55 @@ var (
 // with more common and generic meshkit errors
 
 var (
-	// errPodHasNoLabels is the error for pods with no labels
-	errPodHasNoLabels = fmt.Errorf("the pod has no labels and cannot be exposed")
+	// ErrPodHasNoLabels is the error for pods with no labels
+	ErrPodHasNoLabels = fmt.Errorf("the pod has no labels and cannot be exposed")
 
-	// errServiceHasNoSelectors is the error for service with no selectors
-	errServiceHasNoSelectors = fmt.Errorf("the service has no pod selector set")
+	// ErrServiceHasNoSelectors is the error for service with no selectors
+	ErrServiceHasNoSelectors = fmt.Errorf("the service has no pod selector set")
 
-	// errInvalidDeploymentNoSelectorsLabels is the error for deployment (v1beta1) with no selectors and labels
-	errInvalidDeploymentNoSelectorsLabels = fmt.Errorf("the deployment has no labels or selectors and cannot be exposed")
+	// ErrInvalidDeploymentNoSelectorsLabels is the error for deployment (v1beta1) with no selectors and labels
+	ErrInvalidDeploymentNoSelectorsLabels = fmt.Errorf("the deployment has no labels or selectors and cannot be exposed")
 
-	// errInvalidDeploymentNoSelectors is the error for deployment (v1) with no selectors
-	errInvalidDeploymentNoSelectors = fmt.Errorf("invalid deployment: no selectors, therefore cannot be exposed")
+	// ErrInvalidDeploymentNoSelectors is the error for deployment (v1) with no selectors
+	ErrInvalidDeploymentNoSelectors = fmt.Errorf("invalid deployment: no selectors, therefore cannot be exposed")
 
-	// errInvalidReplicaNoSelectorsLabels is the error for replicaset (v1beta1) with no selectors and labels
-	errInvalidReplicaNoSelectorsLabels = fmt.Errorf("the replica set has no labels or selectors and cannot be exposed")
+	// ErrInvalidReplicaNoSelectorsLabels is the error for replicaset (v1beta1) with no selectors and labels
+	ErrInvalidReplicaNoSelectorsLabels = fmt.Errorf("the replica set has no labels or selectors and cannot be exposed")
 
-	// errInvalidReplicaSetNoSelectors is the error for replicaset (v1) with no selectors
-	errInvalidReplicaSetNoSelectors = fmt.Errorf("invalid replicaset: no selectors, therefore cannot be exposed")
+	// ErrInvalidReplicaSetNoSelectors is the error for replicaset (v1) with no selectors
+	ErrInvalidReplicaSetNoSelectors = fmt.Errorf("invalid replicaset: no selectors, therefore cannot be exposed")
 
-	// errNoPortsFoundForHeadlessResource is the error when no ports are found for non headless resource
-	errNoPortsFoundForHeadlessResource = fmt.Errorf("no ports found for the non headless resource")
+	// ErrNoPortsFoundForHeadlessResource is the error when no ports are found for non headless resource
+	ErrNoPortsFoundForHeadlessResource = fmt.Errorf("no ports found for the non headless resource")
 )
 
-func generateUnknownSessionAffinityErr(sa SessionAffinity) error {
+// ErrUnknownSessionAffinityErr is the error for unknown session affinity
+func ErrUnknownSessionAffinityErr(sa SessionAffinity) error {
 	return fmt.Errorf("unknown session affinity: %s", sa)
 }
 
-func generateMatchExpressionsConvertionErr(me []metav1.LabelSelectorRequirement) error {
+// ErrMatchExpressionsConvertionErr is the error for failed match expression conversion
+func ErrMatchExpressionsConvertionErr(me []metav1.LabelSelectorRequirement) error {
 	return fmt.Errorf("couldn't convert expressions - \"%+v\" to map-based selector format", me)
 }
 
-func generateFailedToExtractPodSelectorErr(object runtime.Object) error {
+// ErrFailedToExtractPodSelectorErr is the error for failed to extract pod selector
+func ErrFailedToExtractPodSelectorErr(object runtime.Object) error {
 	return fmt.Errorf("cannot extract pod selector from %T", object)
 }
 
-func generateFailedToExtractPorts(object runtime.Object) error {
+// ErrFailedToExtractPorts is the error for failed to extract ports
+func ErrFailedToExtractPorts(object runtime.Object) error {
 	return fmt.Errorf("cannot extract ports from %T", object)
 }
 
-func generateFailedToExtractProtocolsErr(object runtime.Object) error {
+// ErrFailedToExtractProtocolsErr is the error for extracting ports
+func ErrFailedToExtractProtocolsErr(object runtime.Object) error {
 	return fmt.Errorf("cannot extract protocols from %T", object)
 }
 
-func generateCannotExposeObjectErr(kind schema.GroupKind) error {
+// ErrCannotExposeObjectErr is the error if the given object cannot be exposed
+func ErrCannotExposeObjectErr(kind schema.GroupKind) error {
 	return fmt.Errorf("cannot expose a %s", kind)
 }
 

--- a/utils/kubernetes/expose/error.go
+++ b/utils/kubernetes/expose/error.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 
 	"github.com/layer5io/meshkit/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var (
@@ -46,6 +49,59 @@ var (
 	// ErrCreatingServiceCode is generated when there is an error deploying the service
 	ErrCreatingServiceCode = "meshkit_test_code"
 )
+
+// Custom errors and generators - These errors are not meshkit errors, they are intended to be wrapped
+// with more common and generic meshkit errors
+
+var (
+	// errPodHasNoLabels is the error for pods with no labels
+	errPodHasNoLabels = fmt.Errorf("the pod has no labels and cannot be exposed")
+
+	// errServiceHasNoSelectors is the error for service with no selectors
+	errServiceHasNoSelectors = fmt.Errorf("the service has no pod selector set")
+
+	// errInvalidDeploymentNoSelectorsLabels is the error for deployment (v1beta1) with no selectors and labels
+	errInvalidDeploymentNoSelectorsLabels = fmt.Errorf("the deployment has no labels or selectors and cannot be exposed")
+
+	// errInvalidDeploymentNoSelectors is the error for deployment (v1) with no selectors
+	errInvalidDeploymentNoSelectors = fmt.Errorf("invalid deployment: no selectors, therefore cannot be exposed")
+
+	// errInvalidReplicaNoSelectorsLabels is the error for replicaset (v1beta1) with no selectors and labels
+	errInvalidReplicaNoSelectorsLabels = fmt.Errorf("the replica set has no labels or selectors and cannot be exposed")
+
+	// errInvalidReplicaSetNoSelectors is the error for replicaset (v1) with no selectors
+	errInvalidReplicaSetNoSelectors = fmt.Errorf("invalid replicaset: no selectors, therefore cannot be exposed")
+
+	// errNoPortsFoundForHeadlessResource is the error when no ports are found for non headless resource
+	errNoPortsFoundForHeadlessResource = fmt.Errorf("no ports found for the non headless resource")
+)
+
+func generateUnknownSessionAffinityErr(sa SessionAffinity) error {
+	return fmt.Errorf("unknown session affinity: %s", sa)
+}
+
+func generateMatchExpressionsConvertionErr(me []metav1.LabelSelectorRequirement) error {
+	return fmt.Errorf("couldn't convert expressions - \"%+v\" to map-based selector format", me)
+}
+
+func generateFailedToExtractPodSelectorErr(object runtime.Object) error {
+	return fmt.Errorf("cannot extract pod selector from %T", object)
+}
+
+func generateFailedToExtractPorts(object runtime.Object) error {
+	return fmt.Errorf("cannot extract ports from %T", object)
+}
+
+func generateFailedToExtractProtocolsErr(object runtime.Object) error {
+	return fmt.Errorf("cannot extract protocols from %T", object)
+}
+
+func generateCannotExposeObjectErr(kind schema.GroupKind) error {
+	return fmt.Errorf("cannot expose a %s", kind)
+}
+
+// Meshkit errors - These errors are intended to wrap more specific errors while maintaining
+// a stack trace within the errors
 
 // ErrExposeResource is the error when there is an error exposing the kubernetes resource
 func ErrExposeResource(err error) error {

--- a/utils/kubernetes/expose/error.go
+++ b/utils/kubernetes/expose/error.go
@@ -1,0 +1,104 @@
+package expose
+
+import (
+	"fmt"
+
+	"github.com/layer5io/meshkit/errors"
+)
+
+var (
+	// ErrGettingResourceCode is generated when there is an error getting the kubernetes resource
+	ErrGettingResourceCode = "linkerd_test_code"
+
+	// ErrTraverserCode is a collection of errors generated during traversing the resources
+	ErrTraverserCode = "linkerd_test_code"
+
+	// ErrResourceCannotBeExposedCode is generated when the given resource cannot be exposed
+	ErrResourceCannotBeExposedCode = "linkerd_test_code"
+
+	// ErrSelectorBasedMapCode is generated when the given resource's selectors can't
+	// be parsed to a map
+	ErrSelectorBasedMapCode = "linkerd_test_code"
+
+	// ErrProtocolBasedMapCode is generated when the given resource's protocol can't
+	// be parsed to a map
+	ErrProtocolBasedMapCode = "linkerd_test_code"
+
+	// ErrLableBasedMapCode is generated when the given resource's protocol can't
+	// be parsed to a map
+	ErrLableBasedMapCode = "linkerd_test_code"
+
+	// ErrPortParsingCode is generated when the given resource's ports can't
+	// be parsed to a slice
+	ErrPortParsingCode = "linkerd_test_code"
+
+	// ErrGenerateServiceCode is generated when a service cannot be generated
+	// for the given resource
+	ErrGenerateServiceCode = "linkerd_test_code"
+
+	// ErrConstructingRestHelperCode is generated when a rest helper cannot be generated
+	// for the generated service
+	ErrConstructingRestHelperCode = "linkerd_test_code"
+
+	// ErrCreatingServiceCode is generated when there is an error deploying the service
+	ErrCreatingServiceCode = "linkerd_test_code"
+)
+
+// ErrGettingResource is the error when there is an error getting the kubernetes resource
+func ErrGettingResource(err error) error {
+	return errors.NewDefault(ErrGettingResourceCode, err.Error())
+}
+
+// ErrTraverser is the error is collection of error generated while traversing the resources
+func ErrTraverser(err error) error {
+	return errors.NewDefault(ErrTraverserCode, err.Error())
+}
+
+// ErrResourceCannotBeExposed is the error if the given resource cannot be exposed
+func ErrResourceCannotBeExposed(err error, resourceKind string) error {
+	return errors.NewDefault(
+		ErrResourceCannotBeExposedCode,
+		fmt.Sprintf("resource type %s cannot be exposed: %s", resourceKind, err.Error()),
+	)
+}
+
+// ErrSelectorBasedMap is the error when the given resource's selectors can't
+// be parsed to a map
+func ErrSelectorBasedMap(err error) error {
+	return errors.NewDefault(ErrSelectorBasedMapCode, err.Error())
+}
+
+// ErrProtocolBasedMap is the error when the given resource's protocols can't
+// be parsed to a map
+func ErrProtocolBasedMap(err error) error {
+	return errors.NewDefault(ErrProtocolBasedMapCode, err.Error())
+}
+
+// ErrLableBasedMap is the error when the given resource's labels can't
+// be parsed to a map
+func ErrLableBasedMap(err error) error {
+	return errors.NewDefault(ErrLableBasedMapCode, err.Error())
+}
+
+// ErrPortParsing is the error when the given resource's ports can't
+// be parsed to a slice
+func ErrPortParsing(err error) error {
+	return errors.NewDefault(ErrPortParsingCode, err.Error())
+}
+
+// ErrGenerateService is the error when a service cannot be generated
+// for the given resource
+func ErrGenerateService(err error) error {
+	return errors.NewDefault(ErrGenerateServiceCode, err.Error())
+}
+
+// ErrConstructingRestHelper is the error when a rest helper cannot be generated
+// for the generated service
+func ErrConstructingRestHelper(err error) error {
+	return errors.NewDefault(ErrConstructingRestHelperCode, err.Error())
+}
+
+// ErrCreatingService is the error when there is an error deploying the service
+func ErrCreatingService(err error) error {
+	return errors.NewDefault(ErrCreatingServiceCode, err.Error())
+}

--- a/utils/kubernetes/expose/error.go
+++ b/utils/kubernetes/expose/error.go
@@ -7,6 +7,9 @@ import (
 )
 
 var (
+	// ErrExposeResourceCode is generated while exposing the kubernetes resource
+	ErrExposeResourceCode = "meshkit_test_code"
+
 	// ErrGettingResourceCode is generated when there is an error getting the kubernetes resource
 	ErrGettingResourceCode = "meshkit_test_code"
 
@@ -44,6 +47,11 @@ var (
 	ErrCreatingServiceCode = "meshkit_test_code"
 )
 
+// ErrExposeResource is the error when there is an error exposing the kubernetes resource
+func ErrExposeResource(err error) error {
+	return errors.NewDefault(ErrExposeResourceCode, err.Error())
+}
+
 // ErrGettingResource is the error when there is an error getting the kubernetes resource
 func ErrGettingResource(err error) error {
 	return errors.NewDefault(ErrGettingResourceCode, err.Error())
@@ -74,9 +82,9 @@ func ErrProtocolBasedMap(err error) error {
 	return errors.NewDefault(ErrProtocolBasedMapCode, err.Error())
 }
 
-// ErrLableBasedMap is the error when the given resource's labels can't
+// ErrLabelBasedMap is the error when the given resource's labels can't
 // be parsed to a map
-func ErrLableBasedMap(err error) error {
+func ErrLabelBasedMap(err error) error {
 	return errors.NewDefault(ErrLableBasedMapCode, err.Error())
 }
 

--- a/utils/kubernetes/expose/expose.go
+++ b/utils/kubernetes/expose/expose.go
@@ -84,8 +84,8 @@ type Config struct {
 	// It will not effect the target resource
 	Annotations map[string]string
 
-	// Logger that would be used for logging
-	Logger logger.Handler
+	// Log is the logger that would be used for logging
+	Log logger.Handler
 }
 
 // serviceConfig extends the Config and is meant to be
@@ -113,7 +113,7 @@ func Expose(
 	tr := Traverser{
 		Client:    clientSet,
 		Resources: resources,
-		Logger:    config.Logger,
+		Logger:    config.Log,
 	}
 	createdSvc, err := tr.Visit(func(info Object, err error) (*v1.Service, error) {
 		if config.Namespace == "" {
@@ -171,14 +171,14 @@ func Expose(
 		if err != nil {
 			return nil, ErrGenerateService(err)
 		}
-		config.Logger.Debug("Generated service object", service.Name, "in namespace", service.Namespace)
+		config.Log.Debug("Generated service object", service.Name, "in namespace", service.Namespace)
 		helper, err := constructObject(clientSet, restConfig, service)
 		if err != nil {
 			return nil, ErrConstructingRestHelper(err)
 		}
 
 		_, err = helper.Create(config.Namespace, false, service)
-		config.Logger.Debug("Service deployed")
+		config.Log.Debug("Service deployed")
 		if err != nil {
 			return nil, ErrCreatingService(err)
 		}

--- a/utils/kubernetes/expose/expose.go
+++ b/utils/kubernetes/expose/expose.go
@@ -158,7 +158,7 @@ func Expose(
 			return nil, ErrPortParsing(err)
 		}
 		if len(ports) == 0 && !isHeadlessService {
-			return nil, ErrPortParsing(errNoPortsFoundForHeadlessResource)
+			return nil, ErrPortParsing(ErrNoPortsFoundForHeadlessResource)
 		}
 
 		service, err := generateService(serviceConfig{
@@ -258,7 +258,7 @@ func generateService(serviceConfig serviceConfig) (*corev1.Service, error) {
 		case corev1.ServiceAffinityClientIP:
 			service.Spec.SessionAffinity = corev1.ServiceAffinityClientIP
 		default:
-			return nil, generateUnknownSessionAffinityErr(serviceConfig.SessionAffinity)
+			return nil, ErrUnknownSessionAffinityErr(serviceConfig.SessionAffinity)
 		}
 	}
 
@@ -286,7 +286,7 @@ func canBeExposed(kind schema.GroupKind) error {
 		extensionsv1beta1.SchemeGroupVersion.WithKind("Deployment").GroupKind(),
 		extensionsv1beta1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind():
 	default:
-		return generateCannotExposeObjectErr(kind)
+		return ErrCannotExposeObjectErr(kind)
 	}
 	return nil
 }
@@ -301,13 +301,13 @@ func mapBasedSelectorForObject(object runtime.Object) (map[string]string, error)
 
 	case *corev1.Pod:
 		if len(t.Labels) == 0 {
-			return map[string]string{}, errPodHasNoLabels
+			return map[string]string{}, ErrPodHasNoLabels
 		}
 		return t.Labels, nil
 
 	case *corev1.Service:
 		if t.Spec.Selector == nil {
-			return map[string]string{}, errServiceHasNoSelectors
+			return map[string]string{}, ErrServiceHasNoSelectors
 		}
 		return t.Spec.Selector, nil
 
@@ -316,44 +316,44 @@ func mapBasedSelectorForObject(object runtime.Object) (map[string]string, error)
 		var labels map[string]string
 		if t.Spec.Selector != nil {
 			if len(t.Spec.Selector.MatchExpressions) > 0 {
-				return map[string]string{}, generateMatchExpressionsConvertionErr(t.Spec.Selector.MatchExpressions)
+				return map[string]string{}, ErrMatchExpressionsConvertionErr(t.Spec.Selector.MatchExpressions)
 			}
 			labels = t.Spec.Selector.MatchLabels
 		} else {
 			labels = t.Spec.Template.Labels
 		}
 		if len(labels) == 0 {
-			return map[string]string{}, errInvalidDeploymentNoSelectorsLabels
+			return map[string]string{}, ErrInvalidDeploymentNoSelectorsLabels
 		}
 		return labels, nil
 
 	case *appsv1.Deployment:
 		// "apps" deployments must have the selector set.
 		if t.Spec.Selector == nil || len(t.Spec.Selector.MatchLabels) == 0 {
-			return map[string]string{}, errInvalidDeploymentNoSelectors
+			return map[string]string{}, ErrInvalidDeploymentNoSelectors
 		}
 		if len(t.Spec.Selector.MatchExpressions) > 0 {
-			return map[string]string{}, generateMatchExpressionsConvertionErr(t.Spec.Selector.MatchExpressions)
+			return map[string]string{}, ErrMatchExpressionsConvertionErr(t.Spec.Selector.MatchExpressions)
 		}
 		return t.Spec.Selector.MatchLabels, nil
 
 	case *appsv1beta2.Deployment:
 		// "apps" deployments must have the selector set.
 		if t.Spec.Selector == nil || len(t.Spec.Selector.MatchLabels) == 0 {
-			return map[string]string{}, errInvalidDeploymentNoSelectors
+			return map[string]string{}, ErrInvalidDeploymentNoSelectors
 		}
 		if len(t.Spec.Selector.MatchExpressions) > 0 {
-			return map[string]string{}, generateMatchExpressionsConvertionErr(t.Spec.Selector.MatchExpressions)
+			return map[string]string{}, ErrMatchExpressionsConvertionErr(t.Spec.Selector.MatchExpressions)
 		}
 		return t.Spec.Selector.MatchLabels, nil
 
 	case *appsv1beta1.Deployment:
 		// "apps" deployments must have the selector set.
 		if t.Spec.Selector == nil || len(t.Spec.Selector.MatchLabels) == 0 {
-			return map[string]string{}, errInvalidDeploymentNoSelectors
+			return map[string]string{}, ErrInvalidDeploymentNoSelectors
 		}
 		if len(t.Spec.Selector.MatchExpressions) > 0 {
-			return map[string]string{}, generateMatchExpressionsConvertionErr(t.Spec.Selector.MatchExpressions)
+			return map[string]string{}, ErrMatchExpressionsConvertionErr(t.Spec.Selector.MatchExpressions)
 		}
 		return t.Spec.Selector.MatchLabels, nil
 
@@ -362,39 +362,39 @@ func mapBasedSelectorForObject(object runtime.Object) (map[string]string, error)
 		var labels map[string]string
 		if t.Spec.Selector != nil {
 			if len(t.Spec.Selector.MatchExpressions) > 0 {
-				return map[string]string{}, generateMatchExpressionsConvertionErr(t.Spec.Selector.MatchExpressions)
+				return map[string]string{}, ErrMatchExpressionsConvertionErr(t.Spec.Selector.MatchExpressions)
 			}
 			labels = t.Spec.Selector.MatchLabels
 		} else {
 			labels = t.Spec.Template.Labels
 		}
 		if len(labels) == 0 {
-			return map[string]string{}, errInvalidReplicaNoSelectorsLabels
+			return map[string]string{}, ErrInvalidReplicaNoSelectorsLabels
 		}
 		return labels, nil
 
 	case *appsv1.ReplicaSet:
 		// "apps" replicasets must have the selector set.
 		if t.Spec.Selector == nil || len(t.Spec.Selector.MatchLabels) == 0 {
-			return map[string]string{}, errInvalidReplicaSetNoSelectors
+			return map[string]string{}, ErrInvalidReplicaSetNoSelectors
 		}
 		if len(t.Spec.Selector.MatchExpressions) > 0 {
-			return map[string]string{}, generateMatchExpressionsConvertionErr(t.Spec.Selector.MatchExpressions)
+			return map[string]string{}, ErrMatchExpressionsConvertionErr(t.Spec.Selector.MatchExpressions)
 		}
 		return t.Spec.Selector.MatchLabels, nil
 
 	case *appsv1beta2.ReplicaSet:
 		// "apps" replicasets must have the selector set.
 		if t.Spec.Selector == nil || len(t.Spec.Selector.MatchLabels) == 0 {
-			return map[string]string{}, errInvalidReplicaSetNoSelectors
+			return map[string]string{}, ErrInvalidReplicaSetNoSelectors
 		}
 		if len(t.Spec.Selector.MatchExpressions) > 0 {
-			return map[string]string{}, generateMatchExpressionsConvertionErr(t.Spec.Selector.MatchExpressions)
+			return map[string]string{}, ErrMatchExpressionsConvertionErr(t.Spec.Selector.MatchExpressions)
 		}
 		return t.Spec.Selector.MatchLabels, nil
 
 	default:
-		return map[string]string{}, generateFailedToExtractPodSelectorErr(object)
+		return map[string]string{}, ErrFailedToExtractPodSelectorErr(object)
 	}
 }
 
@@ -426,7 +426,7 @@ func protocolsForObject(object runtime.Object) (map[string]string, error) {
 		return getProtocols(t.Spec.Template.Spec), nil
 
 	default:
-		return nil, generateFailedToExtractProtocolsErr(object)
+		return nil, ErrFailedToExtractProtocolsErr(object)
 	}
 }
 
@@ -484,7 +484,7 @@ func portsForObject(object runtime.Object) ([]string, error) {
 	case *appsv1beta2.ReplicaSet:
 		return getPorts(t.Spec.Template.Spec), nil
 	default:
-		return nil, generateFailedToExtractPorts(object)
+		return nil, ErrFailedToExtractPorts(object)
 	}
 }
 

--- a/utils/kubernetes/expose/expose.go
+++ b/utils/kubernetes/expose/expose.go
@@ -82,7 +82,7 @@ func Expose(
 	config Config,
 	resources []Resource,
 ) ([]*v1.Service, error) {
-	// continueOnError not only controls if the traversal should continue even after errors
+	// continueOnError controls if the traversal should continue even after errors
 	continueOnError := true
 
 	tr := Traverser{
@@ -122,7 +122,7 @@ func Expose(
 			return nil, ErrProtocolBasedMap(err)
 		}
 
-		// protocolsMap stores the protocols for the current object
+		// labelsMap stores the lables for the current object
 		labelsMap, err := meta.NewAccessor().Labels(info)
 		if err != nil {
 			return nil, ErrLableBasedMap(err)
@@ -146,14 +146,14 @@ func Expose(
 		if err != nil {
 			return nil, ErrGenerateService(err)
 		}
-		config.Logger.Info(fmt.Sprintf("Generated service object %s in namespace %s", service.Name, service.Namespace))
+		config.Logger.Debug(fmt.Sprintf("Generated service object %s in namespace %s", service.Name, service.Namespace))
 		helper, err := constructObject(clientSet, restConfig, service)
 		if err != nil {
 			return nil, ErrConstructingRestHelper(err)
 		}
 
 		_, err = helper.Create(config.Namespace, false, service)
-		config.Logger.Info("Service deployed")
+		config.Logger.Debug("Service deployed")
 		if err != nil {
 			return nil, ErrCreatingService(err)
 		}

--- a/utils/kubernetes/expose/expose.go
+++ b/utils/kubernetes/expose/expose.go
@@ -1,0 +1,521 @@
+package expose
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/layer5io/meshkit/logger"
+	appsv1 "k8s.io/api/apps/v1"
+	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	appsv1beta2 "k8s.io/api/apps/v1beta2"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+)
+
+// Config is a the struct for Expose configuration
+type Config struct {
+	// Type is the type of the service
+	// could be either ClusterIP, NodePort
+	// or LoadBalancer. If an empty is string
+	// is provided then "ClusterIP" type service
+	// is created
+	Type string
+
+	// LoadBalancerIP is the IP address that would
+	// be used if the service type is "loadBalancer"
+	// based. This IP address should be a valid
+	// IP address which can be provisioned by
+	// the service provider
+	LoadBalancerIP string
+
+	// ClusterIP is the IP address that would be
+	// used if the service type is "ClusterIP" or
+	// an empty string. This IP address should be
+	// a valid clusterIP.
+	ClusterIP string
+
+	// Namespace where the service should be created
+	// ideally this should be the same as the service
+	// that needs to be exposed
+	//
+	// It defaults to the namespace of the target resource
+	Namespace string
+
+	// SessionAffinity of the service
+	// could be "None" or "ClientIP"
+	SessionAffinity string
+
+	// Name of the service
+	Name string
+
+	// Logger that would be used for logging
+	Logger logger.Handler
+}
+
+// serviceConfig extends the Config and is meant to be
+// used internally within the expose package.
+//
+// It used to configure the service generator
+type serviceConfig struct {
+	selectorsMap map[string]string
+	labelsMap    map[string]string
+	protocolsMap map[string]string
+	portsSlice   []string
+	Config
+}
+
+// Expose exposes the given kubernetes resource
+func Expose(
+	clientSet *kubernetes.Clientset,
+	restConfig rest.Config,
+	config Config,
+	resources []Resource,
+) ([]*v1.Service, error) {
+	// continueOnError not only controls if the traversal should continue even after errors
+	continueOnError := true
+
+	tr := Traverser{
+		Client:    clientSet,
+		Resources: resources,
+		Logger:    config.Logger,
+	}
+	createdSvc, err := tr.Visit(func(info Object, err error) (*v1.Service, error) {
+		if config.Namespace == "" {
+			config.Namespace = info.GetNamespace()
+		}
+		if err != nil {
+			return nil, nil
+		}
+
+		// Check if the resource can be exposed or not
+		gk := info.GetObjectKind().GroupVersionKind().GroupKind()
+		if err := canBeExposed(gk); err != nil {
+			return nil, ErrResourceCannotBeExposed(err, gk.Kind)
+		}
+
+		if len(config.Name) > validation.DNS1035LabelMaxLength {
+			config.Name = config.Name[:validation.DNS1035LabelMaxLength]
+		}
+
+		// Map for selectors of the current object
+		selectorsMap, err := mapBasedSelectorForObject(info)
+		if err != nil {
+			return nil, ErrSelectorBasedMap(err)
+		}
+
+		isHeadlessService := config.ClusterIP == "None"
+
+		// protocolsMap stores the protocols for the current object
+		protocolsMap, err := protocolsForObject(info)
+		if err != nil {
+			return nil, ErrProtocolBasedMap(err)
+		}
+
+		// protocolsMap stores the protocols for the current object
+		labelsMap, err := meta.NewAccessor().Labels(info)
+		if err != nil {
+			return nil, ErrLableBasedMap(err)
+		}
+
+		ports, err := portsForObject(info)
+		if err != nil {
+			return nil, ErrPortParsing(err)
+		}
+		if len(ports) == 0 && !isHeadlessService {
+			return nil, ErrPortParsing(fmt.Errorf("no ports found for the non headless resource"))
+		}
+
+		service, err := generateService(serviceConfig{
+			selectorsMap: selectorsMap,
+			protocolsMap: protocolsMap,
+			labelsMap:    labelsMap,
+			portsSlice:   ports,
+			Config:       config,
+		})
+		if err != nil {
+			return nil, ErrGenerateService(err)
+		}
+		config.Logger.Info(fmt.Sprintf("Generated service object %s in namespace %s", service.Name, service.Namespace))
+		helper, err := constructObject(clientSet, restConfig, service)
+		if err != nil {
+			return nil, ErrConstructingRestHelper(err)
+		}
+
+		_, err = helper.Create(config.Namespace, false, service)
+		config.Logger.Info("Service deployed")
+		if err != nil {
+			return nil, ErrCreatingService(err)
+		}
+
+		return service, nil
+	}, continueOnError)
+
+	// This err is already generated
+	// from ErrTraverser
+	return createdSvc, err
+}
+
+func generateService(serviceConfig serviceConfig) (*corev1.Service, error) {
+	ports := []corev1.ServicePort{}
+	for i, port := range serviceConfig.portsSlice {
+		// We can expect the port to be a valid UNIX port and hence
+		// should not cause integer overflow. Hence,
+		// #nosec
+		portInt, err := strconv.Atoi(port)
+		if err != nil {
+			return nil, err
+		}
+		portName := ""
+
+		if len(serviceConfig.portsSlice) > 1 {
+			portName = fmt.Sprintf("port-%d", i+1)
+		}
+
+		protocol := "TCP" // Default protocol is "TCP"
+		if exposeProtocol, ok := serviceConfig.protocolsMap[port]; ok {
+			protocol = exposeProtocol
+		}
+
+		ports = append(ports, corev1.ServicePort{
+			Name:     portName,
+			Port:     int32(portInt),
+			Protocol: corev1.Protocol(protocol),
+		})
+	}
+
+	service := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceConfig.Name,
+			Labels:    serviceConfig.labelsMap,
+			Namespace: serviceConfig.Namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: serviceConfig.selectorsMap,
+			Ports:    ports,
+		},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+	}
+
+	// Setup target ports
+	for i := range service.Spec.Ports {
+		port := service.Spec.Ports[i].Port
+		service.Spec.Ports[i].TargetPort = intstr.FromInt(int(port))
+	}
+
+	// Setup service type
+	if len(serviceConfig.Type) != 0 {
+		service.Spec.Type = corev1.ServiceType(serviceConfig.Type)
+	}
+
+	// Setup load balancer ip if the type is load balancer
+	if service.Spec.Type == corev1.ServiceTypeLoadBalancer {
+		service.Spec.LoadBalancerIP = serviceConfig.LoadBalancerIP
+	}
+
+	// Setup session affinity
+	if len(serviceConfig.SessionAffinity) != 0 {
+		switch corev1.ServiceAffinity(serviceConfig.SessionAffinity) {
+		case corev1.ServiceAffinityNone:
+			service.Spec.SessionAffinity = corev1.ServiceAffinityNone
+		case corev1.ServiceAffinityClientIP:
+			service.Spec.SessionAffinity = corev1.ServiceAffinityClientIP
+		default:
+			return nil, fmt.Errorf("unknown session affinity: %s", serviceConfig.SessionAffinity)
+		}
+	}
+
+	// Setup cluster IP
+	if len(serviceConfig.ClusterIP) != 0 {
+		if serviceConfig.ClusterIP == "None" {
+			service.Spec.ClusterIP = corev1.ClusterIPNone
+		} else {
+			service.Spec.ClusterIP = serviceConfig.ClusterIP
+		}
+	}
+
+	return &service, nil
+}
+
+// canBeExposed checks whether the kind of resources could be exposed
+func canBeExposed(kind schema.GroupKind) error {
+	switch kind {
+	case
+		corev1.SchemeGroupVersion.WithKind("ReplicationController").GroupKind(),
+		corev1.SchemeGroupVersion.WithKind("Service").GroupKind(),
+		corev1.SchemeGroupVersion.WithKind("Pod").GroupKind(),
+		appsv1.SchemeGroupVersion.WithKind("Deployment").GroupKind(),
+		appsv1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind(),
+		extensionsv1beta1.SchemeGroupVersion.WithKind("Deployment").GroupKind(),
+		extensionsv1beta1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind():
+	default:
+		return fmt.Errorf("cannot expose a %s", kind)
+	}
+	return nil
+}
+
+// mapBasedSelectorForObject returns the map-based selector associated with the provided object. If a
+// new set-based selector is provided, an error is returned if the selector cannot be converted to a
+// map-based selector
+func mapBasedSelectorForObject(object runtime.Object) (map[string]string, error) {
+	switch t := object.(type) {
+	case *corev1.ReplicationController:
+		return t.Spec.Selector, nil
+
+	case *corev1.Pod:
+		if len(t.Labels) == 0 {
+			return map[string]string{}, fmt.Errorf("the pod has no labels and cannot be exposed")
+		}
+		return t.Labels, nil
+
+	case *corev1.Service:
+		if t.Spec.Selector == nil {
+			return map[string]string{}, fmt.Errorf("the service has no pod selector set")
+		}
+		return t.Spec.Selector, nil
+
+	case *extensionsv1beta1.Deployment:
+		// "extensions" deployments use pod template labels if selector is not set.
+		var labels map[string]string
+		if t.Spec.Selector != nil {
+			if len(t.Spec.Selector.MatchExpressions) > 0 {
+				return map[string]string{}, fmt.Errorf("couldn't convert expressions - \"%+v\" to map-based selector format", t.Spec.Selector.MatchExpressions)
+			}
+			labels = t.Spec.Selector.MatchLabels
+		} else {
+			labels = t.Spec.Template.Labels
+		}
+		if len(labels) == 0 {
+			return map[string]string{}, fmt.Errorf("the deployment has no labels or selectors and cannot be exposed")
+		}
+		return labels, nil
+
+	case *appsv1.Deployment:
+		// "apps" deployments must have the selector set.
+		if t.Spec.Selector == nil || len(t.Spec.Selector.MatchLabels) == 0 {
+			return map[string]string{}, fmt.Errorf("invalid deployment: no selectors, therefore cannot be exposed")
+		}
+		if len(t.Spec.Selector.MatchExpressions) > 0 {
+			return map[string]string{}, fmt.Errorf("couldn't convert expressions - \"%+v\" to map-based selector format", t.Spec.Selector.MatchExpressions)
+		}
+		return t.Spec.Selector.MatchLabels, nil
+
+	case *appsv1beta2.Deployment:
+		// "apps" deployments must have the selector set.
+		if t.Spec.Selector == nil || len(t.Spec.Selector.MatchLabels) == 0 {
+			return map[string]string{}, fmt.Errorf("invalid deployment: no selectors, therefore cannot be exposed")
+		}
+		if len(t.Spec.Selector.MatchExpressions) > 0 {
+			return map[string]string{}, fmt.Errorf("couldn't convert expressions - \"%+v\" to map-based selector format", t.Spec.Selector.MatchExpressions)
+		}
+		return t.Spec.Selector.MatchLabels, nil
+
+	case *appsv1beta1.Deployment:
+		// "apps" deployments must have the selector set.
+		if t.Spec.Selector == nil || len(t.Spec.Selector.MatchLabels) == 0 {
+			return map[string]string{}, fmt.Errorf("invalid deployment: no selectors, therefore cannot be exposed")
+		}
+		if len(t.Spec.Selector.MatchExpressions) > 0 {
+			return map[string]string{}, fmt.Errorf("couldn't convert expressions - \"%+v\" to map-based selector format", t.Spec.Selector.MatchExpressions)
+		}
+		return t.Spec.Selector.MatchLabels, nil
+
+	case *extensionsv1beta1.ReplicaSet:
+		// "extensions" replicasets use pod template labels if selector is not set.
+		var labels map[string]string
+		if t.Spec.Selector != nil {
+			if len(t.Spec.Selector.MatchExpressions) > 0 {
+				return map[string]string{}, fmt.Errorf("couldn't convert expressions - \"%+v\" to map-based selector format", t.Spec.Selector.MatchExpressions)
+			}
+			labels = t.Spec.Selector.MatchLabels
+		} else {
+			labels = t.Spec.Template.Labels
+		}
+		if len(labels) == 0 {
+			return map[string]string{}, fmt.Errorf("the replica set has no labels or selectors and cannot be exposed")
+		}
+		return labels, nil
+
+	case *appsv1.ReplicaSet:
+		// "apps" replicasets must have the selector set.
+		if t.Spec.Selector == nil || len(t.Spec.Selector.MatchLabels) == 0 {
+			return map[string]string{}, fmt.Errorf("invalid replicaset: no selectors, therefore cannot be exposed")
+		}
+		if len(t.Spec.Selector.MatchExpressions) > 0 {
+			return map[string]string{}, fmt.Errorf("couldn't convert expressions - \"%+v\" to map-based selector format", t.Spec.Selector.MatchExpressions)
+		}
+		return t.Spec.Selector.MatchLabels, nil
+
+	case *appsv1beta2.ReplicaSet:
+		// "apps" replicasets must have the selector set.
+		if t.Spec.Selector == nil || len(t.Spec.Selector.MatchLabels) == 0 {
+			return map[string]string{}, fmt.Errorf("invalid replicaset: no selectors, therefore cannot be exposed")
+		}
+		if len(t.Spec.Selector.MatchExpressions) > 0 {
+			return map[string]string{}, fmt.Errorf("couldn't convert expressions - \"%+v\" to map-based selector format", t.Spec.Selector.MatchExpressions)
+		}
+		return t.Spec.Selector.MatchLabels, nil
+
+	default:
+		return map[string]string{}, fmt.Errorf("cannot extract pod selector from %T", object)
+	}
+}
+
+func protocolsForObject(object runtime.Object) (map[string]string, error) {
+	switch t := object.(type) {
+	case *corev1.ReplicationController:
+		return getProtocols(t.Spec.Template.Spec), nil
+
+	case *corev1.Pod:
+		return getProtocols(t.Spec), nil
+
+	case *corev1.Service:
+		return getServiceProtocols(t.Spec), nil
+
+	case *extensionsv1beta1.Deployment:
+		return getProtocols(t.Spec.Template.Spec), nil
+	case *appsv1.Deployment:
+		return getProtocols(t.Spec.Template.Spec), nil
+	case *appsv1beta2.Deployment:
+		return getProtocols(t.Spec.Template.Spec), nil
+	case *appsv1beta1.Deployment:
+		return getProtocols(t.Spec.Template.Spec), nil
+
+	case *extensionsv1beta1.ReplicaSet:
+		return getProtocols(t.Spec.Template.Spec), nil
+	case *appsv1.ReplicaSet:
+		return getProtocols(t.Spec.Template.Spec), nil
+	case *appsv1beta2.ReplicaSet:
+		return getProtocols(t.Spec.Template.Spec), nil
+
+	default:
+		return nil, fmt.Errorf("cannot extract protocols from %T", object)
+	}
+}
+
+func getProtocols(spec corev1.PodSpec) map[string]string {
+	result := make(map[string]string)
+	for _, container := range spec.Containers {
+		for _, port := range container.Ports {
+			// Empty protocol must be defaulted (TCP)
+			if len(port.Protocol) == 0 {
+				port.Protocol = corev1.ProtocolTCP
+			}
+			result[strconv.Itoa(int(port.ContainerPort))] = string(port.Protocol)
+		}
+	}
+	return result
+}
+
+// Extracts the protocols exposed by a service from the given service spec.
+func getServiceProtocols(spec corev1.ServiceSpec) map[string]string {
+	result := make(map[string]string)
+	for _, servicePort := range spec.Ports {
+		// Empty protocol must be defaulted (TCP)
+		if len(servicePort.Protocol) == 0 {
+			servicePort.Protocol = corev1.ProtocolTCP
+		}
+		result[strconv.Itoa(int(servicePort.Port))] = string(servicePort.Protocol)
+	}
+	return result
+}
+
+func portsForObject(object runtime.Object) ([]string, error) {
+	switch t := object.(type) {
+	case *corev1.ReplicationController:
+		return getPorts(t.Spec.Template.Spec), nil
+
+	case *corev1.Pod:
+		return getPorts(t.Spec), nil
+
+	case *corev1.Service:
+		return getServicePorts(t.Spec), nil
+
+	case *extensionsv1beta1.Deployment:
+		return getPorts(t.Spec.Template.Spec), nil
+	case *appsv1.Deployment:
+		return getPorts(t.Spec.Template.Spec), nil
+	case *appsv1beta2.Deployment:
+		return getPorts(t.Spec.Template.Spec), nil
+	case *appsv1beta1.Deployment:
+		return getPorts(t.Spec.Template.Spec), nil
+
+	case *extensionsv1beta1.ReplicaSet:
+		return getPorts(t.Spec.Template.Spec), nil
+	case *appsv1.ReplicaSet:
+		return getPorts(t.Spec.Template.Spec), nil
+	case *appsv1beta2.ReplicaSet:
+		return getPorts(t.Spec.Template.Spec), nil
+	default:
+		return nil, fmt.Errorf("cannot extract ports from %T", object)
+	}
+}
+
+func getPorts(spec corev1.PodSpec) []string {
+	result := []string{}
+	for _, container := range spec.Containers {
+		for _, port := range container.Ports {
+			result = append(result, strconv.Itoa(int(port.ContainerPort)))
+		}
+	}
+	return result
+}
+
+func getServicePorts(spec corev1.ServiceSpec) []string {
+	result := []string{}
+	for _, servicePort := range spec.Ports {
+		result = append(result, strconv.Itoa(int(servicePort.Port)))
+	}
+	return result
+}
+
+func constructObject(kubeClientset kubernetes.Interface, restConfig rest.Config, obj runtime.Object) (*resource.Helper, error) {
+	// Create a REST mapper that tracks information about the available resources in the cluster.
+	groupResources, err := restmapper.GetAPIGroupResources(kubeClientset.Discovery())
+	if err != nil {
+		return nil, err
+	}
+	rm := restmapper.NewDiscoveryRESTMapper(groupResources)
+
+	// Get some metadata needed to make the REST request.
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	gk := schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind}
+	mapping, err := rm.RESTMapping(gk, gvk.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a client specifically for creating the object.
+	restClient, err := newRestClient(restConfig, mapping.GroupVersionKind.GroupVersion())
+	if err != nil {
+		return nil, err
+	}
+
+	// Use the REST helper to create the object in the "default" namespace.
+	return resource.NewHelper(restClient, mapping), nil
+}
+
+func newRestClient(restConfig rest.Config, gv schema.GroupVersion) (rest.Interface, error) {
+	restConfig.ContentConfig = resource.UnstructuredPlusDefaultContentConfig()
+	restConfig.GroupVersion = &gv
+	if len(gv.Group) == 0 {
+		restConfig.APIPath = "/api"
+	} else {
+		restConfig.APIPath = "/apis"
+	}
+
+	return rest.RESTClientFor(&restConfig)
+}

--- a/utils/kubernetes/expose/expose.go
+++ b/utils/kubernetes/expose/expose.go
@@ -23,6 +23,27 @@ import (
 	"k8s.io/client-go/restmapper"
 )
 
+// SessionAffinity is the type for Kubernetes resources' SessionAffinity
+type SessionAffinity string
+
+const (
+	// None is the "None" type SessionAffinity
+	None SessionAffinity = "None"
+
+	// ClientIP is the "ClientIP" type SessionAffinity
+	ClientIP SessionAffinity = "ClientIP"
+)
+
+// ServiceType us the type for Kubernetes resources' Type
+type ServiceType string
+
+// Supported service type
+const (
+	ClusterIP    ServiceType = "ClusterIP"
+	NodePort     ServiceType = "NodePort"
+	LoadBalancer ServiceType = "LoadBalancer"
+)
+
 // Config is a the struct for Expose configuration
 type Config struct {
 	// Type is the type of the service
@@ -30,7 +51,7 @@ type Config struct {
 	// or LoadBalancer. If an empty is string
 	// is provided then "ClusterIP" type service
 	// is created
-	Type string
+	Type ServiceType
 
 	// LoadBalancerIP is the IP address that would
 	// be used if the service type is "loadBalancer"
@@ -54,7 +75,7 @@ type Config struct {
 
 	// SessionAffinity of the service
 	// could be "None" or "ClientIP"
-	SessionAffinity string
+	SessionAffinity SessionAffinity
 
 	// Name of the service
 	Name string

--- a/utils/kubernetes/expose/remove.go
+++ b/utils/kubernetes/expose/remove.go
@@ -1,0 +1,13 @@
+package expose
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Remove deletes the given service
+func Remove(svc, ns string, client *kubernetes.Clientset) error {
+	return client.CoreV1().Services(ns).Delete(context.TODO(), svc, metav1.DeleteOptions{})
+}

--- a/utils/kubernetes/expose/traverser.go
+++ b/utils/kubernetes/expose/traverser.go
@@ -1,0 +1,213 @@
+package expose
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/layer5io/meshkit/logger"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Traverser can be used to traverse resources in the cluster
+type Traverser struct {
+	Resources []Resource
+
+	Client *kubernetes.Clientset
+
+	Logger logger.Handler
+}
+
+// Resource defines the structure for the resource definition
+// used by the traverser to locate the kubernetes resources
+type Resource struct {
+	Namespace string
+	Type      string
+	Name      string
+}
+
+// Object is the interface extending kubernetes' runtime
+// object interface
+type Object interface {
+	runtime.Object
+	GetNamespace() string
+	GetName() string
+}
+
+// VisitCB is the type for callback function that is invoked
+// when the traverser reaches one of the given kubernetes resource
+//
+// The first argument for the VisitCB is the kubernetes resource itself
+// while the other is the error that may have occured in the traverser
+// in case this error is not nil, then this callbac function may return
+// without executing the code
+type VisitCB = func(Object, error) (*v1.Service, error)
+
+// Visit function traverses each of the resource mentioned in the Traverser struct
+func (traverser *Traverser) Visit(f VisitCB, continueOnError bool) ([]*v1.Service, error) {
+	var errs []error
+	var accumulatedSvcs []*v1.Service
+
+	for _, res := range traverser.Resources {
+		ns := res.Namespace // Namespace in which the resoruce should be searched
+		typ := res.Type     // Type of the resource
+		name := res.Name    // Name of the resource
+
+		switch typ {
+		case "Service":
+			svc, err := traverser.Client.CoreV1().Services(ns).Get(context.TODO(), name, metav1.GetOptions{})
+			if err != nil {
+				traverser.Logger.Error(err)
+				errs = append(errs, err)
+				if !continueOnError {
+					return accumulatedSvcs, ErrGettingResource(err)
+				}
+			}
+			// Placing Kind and APIVersion manually
+			// because client-go omits them
+			// Please do no remove
+			svc.Kind = typ
+			svc.APIVersion = "v1"
+			genSvc, err := f(svc, err)
+			if err != nil {
+				traverser.Logger.Error(err)
+				errs = append(errs, err)
+				if !continueOnError {
+					return accumulatedSvcs, ErrGettingResource(err)
+				}
+			}
+			if genSvc != nil {
+				accumulatedSvcs = append(accumulatedSvcs, genSvc)
+			}
+		case "Pod":
+			pod, err := traverser.Client.CoreV1().Pods(ns).Get(context.TODO(), name, metav1.GetOptions{})
+			if err != nil {
+				traverser.Logger.Error(err)
+				errs = append(errs, err)
+				if !continueOnError {
+					return accumulatedSvcs, ErrGettingResource(err)
+				}
+			}
+			// Placing Kind and APIVersion manually
+			// because client-go omits them
+			// Please do no remove
+			pod.Kind = typ
+			pod.APIVersion = "v1"
+			genSvc, err := f(pod, err)
+			if err != nil {
+				traverser.Logger.Error(err)
+				errs = append(errs, err)
+				if !continueOnError {
+					return accumulatedSvcs, ErrGettingResource(err)
+				}
+			}
+			if genSvc != nil {
+				accumulatedSvcs = append(accumulatedSvcs, genSvc)
+			}
+		case "ReplicationController":
+			rc, err := traverser.Client.CoreV1().ReplicationControllers(ns).Get(context.TODO(), name, metav1.GetOptions{})
+			if err != nil {
+				traverser.Logger.Error(err)
+				errs = append(errs, err)
+				if !continueOnError {
+					return accumulatedSvcs, ErrGettingResource(err)
+				}
+			}
+			// Placing Kind and APIVersion manually
+			// because client-go omits them
+			// Please do no remove
+			rc.Kind = typ
+			rc.APIVersion = "v1"
+			genSvc, err := f(rc, err)
+			if err != nil {
+				traverser.Logger.Error(err)
+				errs = append(errs, err)
+				if !continueOnError {
+					return accumulatedSvcs, ErrGettingResource(err)
+				}
+			}
+			if genSvc != nil {
+				accumulatedSvcs = append(accumulatedSvcs, genSvc)
+			}
+		case "Deployment":
+			dep, err := traverser.Client.AppsV1().Deployments(ns).Get(context.TODO(), name, metav1.GetOptions{})
+			if err != nil {
+				traverser.Logger.Error(err)
+				errs = append(errs, err)
+				if !continueOnError {
+					return accumulatedSvcs, ErrGettingResource(err)
+				}
+			}
+			// Placing Kind and APIVersion manually
+			// because client-go omits them
+			// Please do no remove
+			dep.Kind = typ
+			dep.APIVersion = "apps/v1"
+			genSvc, err := f(dep, err)
+			if err != nil {
+				traverser.Logger.Error(err)
+				errs = append(errs, err)
+				if !continueOnError {
+					return accumulatedSvcs, ErrGettingResource(err)
+				}
+			}
+			if genSvc != nil {
+				accumulatedSvcs = append(accumulatedSvcs, genSvc)
+			}
+		case "ReplicaSet":
+			reps, err := traverser.Client.AppsV1().ReplicaSets(ns).Get(context.TODO(), name, metav1.GetOptions{})
+			if err != nil {
+				traverser.Logger.Error(err)
+				errs = append(errs, err)
+				if !continueOnError {
+					return accumulatedSvcs, ErrGettingResource(err)
+				}
+			}
+			// Placing Kind and APIVersion manually
+			// because client-go omits them
+			// Please do no remove
+			reps.Kind = typ
+			reps.APIVersion = "apps/v1"
+			genSvc, err := f(reps, err)
+			if err != nil {
+				traverser.Logger.Error(err)
+				errs = append(errs, err)
+				if !continueOnError {
+					return accumulatedSvcs, ErrGettingResource(err)
+				}
+			}
+			if genSvc != nil {
+				accumulatedSvcs = append(accumulatedSvcs, genSvc)
+			}
+		default:
+			// Don't do anything
+			traverser.Logger.Warn(fmt.Errorf("invalid resource type"))
+		}
+	}
+
+	err := combineErrors(errs, "\n")
+	if err != nil {
+		return accumulatedSvcs, ErrTraverser(err)
+	}
+
+	return accumulatedSvcs, nil
+}
+
+// combineErrors merges a slice of error
+// into one error separated by the given separator
+func combineErrors(errs []error, sep string) error {
+	if len(errs) == 0 {
+		return nil
+	}
+
+	var errString []string
+	for _, err := range errs {
+		errString = append(errString, err.Error())
+	}
+
+	return errors.New(strings.Join(errString, sep))
+}


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

**Description**
This PR adds an `Expose` function which can be used to expose any of the following resources:
1. Pods (tested)
2. Services (tested)
3. Deployments (tested)
4. ReplicaSets (not tested)
5. Replication Controllers (not tested)

It returns the created services which can be used in another meshkit's function called `GetServiceEndpoint` to get the address of these services.

Usage example:
```golang
// Expose the service
_, err = expose.Expose(clientset, *config, expose.Config{
	Name:   "nginx-service-meshery", // Name of the service that will be created
	Type:   "NodePort", // Type of the service that will be created
	Logger: logr, // Logger used internally
}, []expose.Resource{{Namespace: "utkarsh-test", Name: "nginx-service", Type: "Service"}})
if err != nil {
	log.Fatal(err)
}

// Get the endpoint for the service
ep, err = kb.GetServiceEndpoint(context.TODO(), "nginx-service-meshery", "utkarsh-test")
if err != nil {
	log.Fatal(err)
}

// Remove the exposed service
err = expose.Remove("nginx-service-meshery", "utkarsh-test", clientset)
if err != nil {
	log.Fatal(err)
}
```

**Notes for Reviewers**
@Aisuko, I have added comments this time as you suggested earlier

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
