### PR TITLE
Add multi protocol supported file loader

### DIFF
--- a/errors/codes.go
+++ b/errors/codes.go
@@ -45,6 +45,7 @@ var (
 	ErrGetBool          = "kit_10205"
 	ErrApplyManifest    = "kit_10206"
 	ErrServiceDiscovery = "kit_10207"
+	ErrLoadFile         = "kit_10208"
 
 	// Istio Service mesh specific codes
 	// Range 11000 to 11099

--- a/utils/error.go
+++ b/utils/error.go
@@ -38,3 +38,19 @@ func ErrMarshal(err error) error {
 func ErrGetBool(key string, err error) error {
 	return errors.NewDefault(errors.ErrGetBool, fmt.Sprintf("Error while getting Boolean value for key: %s, error: %s", key, err.Error()))
 }
+
+func ErrInvalidProtocol() error {
+	return errors.NewDefault(errors.ErrLoadFile, "invalid protocol: only http, https and file are valid protocols")
+}
+
+func ErrRemoteFileNotFound(url string) error {
+	return errors.NewDefault(errors.ErrLoadFile, fmt.Sprintf("remote file not found at %s", url))
+}
+
+func ErrReadingRemoteFile(err error) error {
+	return errors.NewDefault(errors.ErrLoadFile, fmt.Sprintf("error reading remote file: %s", err))
+}
+
+func ErrReadingLocalFile(err error) error {
+	return errors.NewDefault(errors.ErrLoadFile, fmt.Sprintf("error reading local file: %s", err))
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"os/user"
@@ -122,10 +123,32 @@ func CreateFile(contents []byte, filename string, location string) error {
 	return nil
 }
 
+// ReadFileSource supports "http", "https" and "file" protocols.
+// it takes in the location as a uri and returns the contents of
+// file as a string.
+//
+func ReadFileSource(uri string) (string, error) {
+	if strings.HasPrefix(uri, "http") {
+		return ReadRemoteFile(uri)
+	}
+	if strings.HasPrefix(uri, "file") {
+		return ReadLocalFile(uri)
+	}
+
+	return "", fmt.Errorf("invalid protocol: only http, https and file are valid protocols")
+}
+
+// ReadRemoteFile takes in the location of a remote file
+// in the format 'http://location/of/file' or 'https://location/file'
+// and returns the content of the file if the location is valid and
+// no error occurs
 func ReadRemoteFile(url string) (string, error) {
 	response, err := http.Get(url)
 	if err != nil {
 		return " ", err
+	}
+	if response.StatusCode == http.StatusNotFound {
+		return " ", fmt.Errorf("remote file not found at %s", url)
 	}
 
 	defer response.Body.Close()
@@ -137,4 +160,22 @@ func ReadRemoteFile(url string) (string, error) {
 	}
 
 	return buf.String(), nil
+}
+
+// ReadLocalFile takes in the location of a local file
+// in the format `file://location/of/file` and returns
+// the content of the file if the path is valid and no
+// error occurs
+func ReadLocalFile(location string) (string, error) {
+	// remove the protocol prefix
+	location = strings.TrimPrefix(location, "file://")
+
+	// Need to support variable file locations hence
+	// #nosec
+	data, err := ioutil.ReadFile(location)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -126,7 +126,6 @@ func CreateFile(contents []byte, filename string, location string) error {
 // ReadFileSource supports "http", "https" and "file" protocols.
 // it takes in the location as a uri and returns the contents of
 // file as a string.
-//
 func ReadFileSource(uri string) (string, error) {
 	if strings.HasPrefix(uri, "http") {
 		return ReadRemoteFile(uri)
@@ -135,7 +134,7 @@ func ReadFileSource(uri string) (string, error) {
 		return ReadLocalFile(uri)
 	}
 
-	return "", fmt.Errorf("invalid protocol: only http, https and file are valid protocols")
+	return "", ErrInvalidProtocol()
 }
 
 // ReadRemoteFile takes in the location of a remote file
@@ -148,7 +147,7 @@ func ReadRemoteFile(url string) (string, error) {
 		return " ", err
 	}
 	if response.StatusCode == http.StatusNotFound {
-		return " ", fmt.Errorf("remote file not found at %s", url)
+		return " ", ErrRemoteFileNotFound(url)
 	}
 
 	defer response.Body.Close()
@@ -156,7 +155,7 @@ func ReadRemoteFile(url string) (string, error) {
 	buf := new(bytes.Buffer)
 	_, err = io.Copy(buf, response.Body)
 	if err != nil {
-		return " ", err
+		return " ", ErrReadingRemoteFile(err)
 	}
 
 	return buf.String(), nil
@@ -174,7 +173,7 @@ func ReadLocalFile(location string) (string, error) {
 	// #nosec
 	data, err := ioutil.ReadFile(location)
 	if err != nil {
-		return "", err
+		return "", ErrReadingLocalFile(err)
 	}
 
 	return string(data), nil


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

**Description**
This PR moves the file loader function that we had in istio and linkerd adapters to meshkit. 

**Usage**
```golang
// http protocol
file, err := ReadFileSource("http://location/of/the/file")

// https protocol
file, err := ReadFileSource("https://location/of/the/file")

// file protocol
file, err := ReadFileSource("file://location/of/the/file")
```
**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
