### PR TITLE
Add ApplyHelmChart function

### DIFF
--- a/errors/codes.go
+++ b/errors/codes.go
@@ -46,6 +46,7 @@ var (
 	ErrApplyManifest    = "kit_10206"
 	ErrServiceDiscovery = "kit_10207"
 	ErrLoadFile         = "kit_10208"
+	ErrApplyHelmChart   = "kit_10209"
 
 	// Istio Service mesh specific codes
 	// Range 11000 to 11099

--- a/utils/kubernetes/apply-helm-chart.go
+++ b/utils/kubernetes/apply-helm-chart.go
@@ -1,0 +1,271 @@
+package kubernetes
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/layer5io/meshkit/utils"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/getter"
+	"helm.sh/helm/v3/pkg/repo"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
+)
+
+// HelmDriver is the type for helm drivers
+type HelmDriver string
+
+const (
+	// ConfigMap HelmDriver can be used to instruct
+	// helm to use configmaps as backend
+	ConfigMap HelmDriver = "configmap"
+
+	// Secret HelmDriver can be used to instruct
+	// helm to use secrets as backend
+	Secret HelmDriver = "secret"
+
+	// SQL HelmDriver can be used to instruct
+	// helm to use sql as backend
+	//
+	// This should be used when release information
+	// is expected to be greater than 1MB
+	SQL HelmDriver = "sql"
+)
+
+const (
+	// Stable is the default repository for helm v3
+	Stable = "https://charts.helm.sh/stable"
+)
+
+var (
+	// downloadLocaton is the location where downloaded helm charts
+	// will be stored. os.TempDir will ensure that the path is cross
+	// platform
+	downloadLocation = os.TempDir()
+)
+
+// HelmChartLocation describes the structure for defining
+// the location for helm chart
+type HelmChartLocation struct {
+	// Repository is the url of the helm repository
+	//
+	// Defaults to https://charts.helm.sh/stable
+	Repository string
+
+	// Chart is the name of the chart that is supposed
+	// to be installed. This chart must me present in the
+	// https://REPOSITORY/index.yaml
+	Chart string
+}
+
+// ApplyHelmChartConfig defines the options that ApplyHelmChart
+// can take
+type ApplyHelmChartConfig struct {
+	// ChartLocation is the remote location of the helm chart
+	//
+	// Either ChartLocation or URL can be defined, if both of them
+	// are defined then URL is given the preferenece
+	ChartLocation HelmChartLocation
+
+	// URL is the url for charts
+	//
+	// Either ChartLocation or URL can be defined, if both of them
+	// are defined then URL is given the preferenece
+	URL string
+
+	// HelmDriver is used to determine the backend
+	// informations used by helm for managing release
+	//
+	// Defaults to Secret
+	HelmDriver HelmDriver
+
+	// SQLConnectionString is the connection uri
+	// for the postgresql database which will be used if
+	// the HelmDriver is set to SQL
+	SQLConnectionString string
+
+	// Namespace in which the resources are supposed to
+	// be deployed
+	//
+	// Defaults to "default"
+	Namespace string
+
+	// CreateNamespace creates namespace if it doesn't exists
+	//
+	// Defaults to false
+	CreateNamespace bool
+
+	// OverrideValues are used during installation
+	// to override the the values present in Values.yaml
+	// it is equivalent to --set or --set-file helm flag
+	OverrideValues map[string]interface{}
+
+	// Delete indicates if the requested action is a delete
+	// action
+	//
+	// Defaults to false
+	Delete bool
+}
+
+// ApplyHelmChart takes in the url for the helm chart
+// and applies that chart as per the ApplyHelmChartOptions
+func (client *Client) ApplyHelmChart(cfg ApplyHelmChartConfig) error {
+	setupDefaults(&cfg)
+
+	url, err := getHelmChartURL(cfg)
+	if err != nil {
+		return ErrApplyHelmChart(err)
+	}
+
+	localPath, err := fetchHelmChart(url)
+	if err != nil {
+		return ErrApplyHelmChart(err)
+	}
+
+	chart, err := loader.Load(localPath)
+	if err != nil {
+		return ErrApplyHelmChart(err)
+	}
+
+	if err := checkIfInstallable(chart); err != nil {
+		return ErrApplyHelmChart(err)
+	}
+
+	actionConfig, err := createHelmActionConfig(client.RestConfig, cfg)
+	if err != nil {
+		return ErrApplyHelmChart(err)
+	}
+
+	if err := generateAction(actionConfig, cfg)(chart); err != nil {
+		return ErrApplyHelmChart(err)
+	}
+
+	return nil
+}
+
+// setupDefaults adds the default value to the configuration
+func setupDefaults(cfg *ApplyHelmChartConfig) {
+	if cfg.URL == "" && cfg.ChartLocation.Repository == "" {
+		cfg.ChartLocation.Repository = Stable
+	}
+	if cfg.HelmDriver == "" {
+		cfg.HelmDriver = Secret
+	}
+	if cfg.Namespace == "" {
+		cfg.Namespace = "default"
+	}
+}
+
+// getHelmChartURL returns the chart url irrespective of the chosen method for
+// performing action
+func getHelmChartURL(cfg ApplyHelmChartConfig) (string, error) {
+	if cfg.URL == "" {
+		return createHelmPathFromHelmChartLocation(cfg.ChartLocation)
+	}
+
+	return cfg.URL, nil
+}
+
+// fetchHelmChart downloads the charts from the given url and returns
+// the location of the downloaded chart
+//
+// if the chart is already present in the download location
+// then the download is skipped
+func fetchHelmChart(chartURL string) (string, error) {
+	filename := filepath.Base(chartURL)
+	downloadPath := path.Join(downloadLocation, filename)
+
+	// Skip the download if chart already exists
+	if _, err := os.Stat(downloadPath); err == nil {
+		return downloadPath, nil
+	}
+
+	if err := utils.DownloadFile(downloadPath, chartURL); err != nil {
+		return "", ErrApplyHelmChart(err)
+	}
+
+	return downloadPath, nil
+}
+
+// checkIfInstallable validates if a chart can be installed
+//
+// Application chart type is only installable
+func checkIfInstallable(ch *chart.Chart) error {
+	switch ch.Metadata.Type {
+	case "", "application":
+		return nil
+	}
+	return ErrApplyHelmChart(fmt.Errorf("%s charts are not installable", ch.Metadata.Type))
+}
+
+// createHelmActionConfig generates the actionConfig with the appropriate defaults
+func createHelmActionConfig(restConfig rest.Config, cfg ApplyHelmChartConfig) (*action.Configuration, error) {
+	kubeConfig := genericclioptions.NewConfigFlags(false)
+	kubeConfig.APIServer = &restConfig.Host
+	kubeConfig.BearerToken = &restConfig.BearerToken
+	kubeConfig.CAFile = &restConfig.CAFile
+
+	nopLogger := func(_ string, _ ...interface{}) {} // Dummy logger for helm packages
+
+	actionConfig := new(action.Configuration)
+	if err := actionConfig.Init(kubeConfig, cfg.Namespace, string(cfg.HelmDriver), nopLogger); err != nil {
+		return nil, ErrApplyHelmChart(err)
+	}
+
+	return actionConfig, nil
+}
+
+// generateAction generates an action function using action.Configuration
+// and ApplyHelmChartConfig and returns it
+//
+// The intention is to create a factory function which creates a layer of abstraction
+// on top of helm actions making them follow the same interface, hence easing extending
+// the number of supported helm actions
+func generateAction(actionConfig *action.Configuration, cfg ApplyHelmChartConfig) func(*chart.Chart) error {
+	if cfg.Delete {
+		return func(c *chart.Chart) error {
+			act := action.NewUninstall(actionConfig)
+			if _, err := act.Run(c.Name()); err != nil {
+				return ErrApplyHelmChart(err)
+			}
+
+			return nil
+		}
+	}
+
+	return func(c *chart.Chart) error {
+		act := action.NewInstall(actionConfig)
+		act.ReleaseName = c.Name()
+		act.CreateNamespace = cfg.CreateNamespace
+		act.Namespace = cfg.Namespace
+		if _, err := act.Run(c, cfg.OverrideValues); err != nil {
+			return ErrApplyHelmChart(err)
+		}
+
+		return nil
+	}
+}
+
+// createHelmPathFromHelmChartLocation takes in the HelmChartLocation and returns the
+// chart url which can be used to download the chart
+func createHelmPathFromHelmChartLocation(loc HelmChartLocation) (string, error) {
+	if loc.Chart == "" {
+		return "", ErrApplyHelmChart(fmt.Errorf("\"Chart\" cannot be empty"))
+	}
+
+	chartURL, err := repo.FindChartInRepoURL(loc.Repository, loc.Chart, ">0.0.0-0", "", "", "", getter.Providers{
+		getter.Provider{
+			Schemes: []string{"http", "https"},
+			New:     getter.NewHTTPGetter,
+		}},
+	)
+	if err != nil {
+		return "", ErrApplyHelmChart(err)
+	}
+
+	return chartURL, nil
+}

--- a/utils/kubernetes/apply-helm-chart.go
+++ b/utils/kubernetes/apply-helm-chart.go
@@ -204,6 +204,10 @@ func checkIfInstallable(ch *chart.Chart) error {
 
 // createHelmActionConfig generates the actionConfig with the appropriate defaults
 func createHelmActionConfig(restConfig rest.Config, cfg ApplyHelmChartConfig) (*action.Configuration, error) {
+	// Set the environment variable needed by the Init method
+	os.Setenv("HELM_DRIVER_SQL_CONNECTION_STRING", cfg.SQLConnectionString)
+
+	// KubeConfig setup
 	kubeConfig := genericclioptions.NewConfigFlags(false)
 	kubeConfig.APIServer = &restConfig.Host
 	kubeConfig.BearerToken = &restConfig.BearerToken

--- a/utils/kubernetes/error.go
+++ b/utils/kubernetes/error.go
@@ -10,3 +10,8 @@ func ErrApplyManifest(err error) error {
 func ErrServiceDiscovery(err error) error {
 	return errors.NewDefault(errors.ErrServiceDiscovery, "Error Discovering service: "+err.Error())
 }
+
+// ErrApplyHelmChart is the error which occurs in the process of applying helm chart
+func ErrApplyHelmChart(err error) error {
+	return errors.NewDefault(errors.ErrApplyHelmChart, "Error applying helm chart: "+err.Error())
+}


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

**Description**
This PR adds `ApplyHelmChart` function. The intent is to have a utility function to help apply custom helm charts.
Supports:
- Installation and uninstallation of charts
- All storage drivers
- chart location as a url as well as in form of repository (url) and chart name.
- Override values (equivalent to --set in helm)

Usage:

```golang
// Install traefik service mesh using URL
err = client.ApplyHelmChart(k8s.ApplyHelmChartConfig{
		Namespace:       "traefik-mesh",
		CreateNamespace: true,
		URL:             "https://helm.traefik.io/mesh/traefik-mesh-3.0.6.tgz",
})

// Install traefik service mesh using repository
err = cl.ApplyHelmChart(k8s.ApplyHelmChartConfig{
		ChartLocation: k8s.HelmChartLocation{
			Repository: "https://helm.traefik.io/mesh",
			Chart:      "traefik-mesh",
		},
		Namespace:       "traefik-mesh",
		CreateNamespace: true,
})
```

Tests Done: 
Install/Uninstall Traefik Service Mesh using:
- [x] Repository and chart name
- [x] URL 
- [x] SQL Driver (postgresql db)
- [x] ConfigMap
- [x] Secret

**Notes for Reviewers**
This is the first step towards traefik service mesh :slightly_smiling_face: 

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
