### PR TITLE
Fix segmentation fault

### DIFF
--- a/utils/kubernetes/apply-manifest.go
+++ b/utils/kubernetes/apply-manifest.go
@@ -40,8 +40,11 @@ func (client *Client) ApplyManifest(contents []byte, recvOptions ApplyOptions) e
 		options := recvOptions
 
 		// get the runtime.Object
-		object, _, err := client.GetObjectFromManifest(manifest)
+		object, obj, err := client.GetObjectFromManifest(manifest)
 		if err != nil {
+			if len(obj.GetObjectKind().GroupVersionKind().Kind) < 1 {
+				continue
+			}
 			return ErrApplyManifest(err)
 		}
 
@@ -89,8 +92,8 @@ func (client *Client) GetObjectFromManifest(manifest string) (runtime.Object, *u
 	obj := &unstructured.Unstructured{}
 	dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
 	object, _, err := dec.Decode([]byte(manifest), nil, obj)
-	if err != nil && len(obj.GetObjectKind().GroupVersionKind().Kind) > 1 {
-		return nil, nil, ErrApplyManifest(err)
+	if err != nil {
+		return nil, obj, ErrApplyManifest(err)
 	}
 	return object, obj, nil
 }


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

**Description**
This PR fixes #25.

**Notes for Reviewers**
Issue description: 
- The issue was in both linkerd as well as istio adapter. 
- The reason was that we were no longer rejecting the invalid kubernetes yaml. For linkerd it is the comments in the yaml which were causing the issue and for istio, the install process works but is broken that's why it emits out invalid manifest. Istio install process would be addressed in a subsequent PR.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
