### PR TITLE
Add map type for native sql driver

### DIFF
--- a/database/error.go
+++ b/database/error.go
@@ -3,12 +3,42 @@ package database
 import "github.com/layer5io/meshkit/errors"
 
 var (
-	ErrNoneDatabaseCode = "test"
-	ErrDatabaseOpenCode = "test"
+	ErrNoneDatabaseCode           = "test"
+	ErrDatabaseOpenCode           = "test"
+	ErrSQLMapUnmarshalJSONCode    = "test"
+	ErrSQLMapUnmarshalTextCode    = "test"
+	ErrSQLMapMarshalValueCode     = "test"
+	ErrSQLMapUnmarshalScannedCode = "test"
+	ErrSQLMapInvalidScanCode      = "test"
 
-	ErrNoneDatabase = errors.NewDefault(ErrNoneDatabaseCode, "No Database selected")
+	ErrNoneDatabase      = errors.NewDefault(ErrNoneDatabaseCode, "No Database selected")
+	ErrSQLMapInvalidScan = errors.NewDefault(ErrSQLMapUnmarshalScannedCode, "invalid data type: expected []byte")
 )
 
 func ErrDatabaseOpen(err error) error {
 	return errors.NewDefault(ErrDatabaseOpenCode, "Unable to open database", err.Error())
+}
+
+// ErrSQLMapUnmarshalJSON represents the error which will occur when the native SQL driver
+// will fail to unmarshal the JSON
+func ErrSQLMapUnmarshalJSON(err error) error {
+	return errors.NewDefault(ErrSQLMapUnmarshalJSONCode, "failed to unmarshal json", err.Error())
+}
+
+// ErrSQLMapUnmarshalJSON represents the error which will occur when the native SQL driver
+// will fail to unmarshal the text
+func ErrSQLMapUnmarshalText(err error) error {
+	return errors.NewDefault(ErrSQLMapUnmarshalTextCode, "failed to unmarshal text", err.Error())
+}
+
+// ErrSQLMapMarshalValue represents the error which will occur when the native SQL driver
+// will fail to marshal the value
+func ErrSQLMapMarshalValue(err error) error {
+	return errors.NewDefault(ErrSQLMapMarshalValueCode, "failed to marshal value", err.Error())
+}
+
+// ErrSQLMapUnmarshalScanned represents the error which will occur when the native SQL driver
+// will fail to unmarshal the scanned data
+func ErrSQLMapUnmarshalScanned(err error) error {
+	return errors.NewDefault(ErrSQLMapUnmarshalScannedCode, "failed to unmarshal scanned data", err.Error())
 }

--- a/database/sql.go
+++ b/database/sql.go
@@ -3,8 +3,6 @@ package database
 import (
 	"database/sql/driver"
 	"encoding/json"
-
-	"errors"
 )
 
 // Map type is an alias for map[string]interface{}
@@ -24,11 +22,11 @@ func (m Map) Interface() interface{} {
 func (m *Map) Scan(src interface{}) error {
 	b, ok := src.([]byte)
 	if !ok {
-		return errors.New("scan source is not of type []byte")
+		return ErrSQLMapInvalidScan
 	}
 
 	if err := json.Unmarshal(b, m); err != nil {
-		return err
+		return ErrSQLMapUnmarshalScanned(err)
 	}
 
 	return nil
@@ -39,7 +37,7 @@ func (m *Map) Scan(src interface{}) error {
 func (m Map) Value() (driver.Value, error) {
 	b, err := json.Marshal(m)
 	if err != nil {
-		return nil, err
+		return nil, ErrSQLMapMarshalValue(err)
 	}
 
 	return string(b), nil
@@ -51,7 +49,7 @@ func (m Map) UnmarshalJSON(b []byte) error {
 	var stuff map[string]interface{}
 
 	if err := json.Unmarshal(b, &stuff); err != nil {
-		return err
+		return ErrSQLMapUnmarshalJSON(err)
 	}
 
 	for key, value := range stuff {
@@ -65,7 +63,7 @@ func (m Map) UnmarshalJSON(b []byte) error {
 // the map representation of this value.
 func (m Map) UnmarshalText(text []byte) error {
 	if err := json.Unmarshal(text, &m); err != nil {
-		return err
+		return ErrSQLMapUnmarshalText(err)
 	}
 
 	return nil

--- a/database/sql.go
+++ b/database/sql.go
@@ -1,0 +1,72 @@
+package database
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+
+	"errors"
+)
+
+// Map type is an alias for map[string]interface{}
+//
+// It implements native SQL driver interfaces and hence can
+// be used for SQL json or jsonb types as a drop in replacement
+// of golang native maps
+type Map map[string]interface{}
+
+// Interface implements the nulls.nullable interface.
+func (m Map) Interface() interface{} {
+	return map[string]interface{}(m)
+}
+
+// Scan implements the sql.Scanner interface.
+// It allows to read the map from the database value.
+func (m *Map) Scan(src interface{}) error {
+	b, ok := src.([]byte)
+	if !ok {
+		return errors.New("scan source is not of type []byte")
+	}
+
+	if err := json.Unmarshal(b, m); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Value implements the driver.Valuer interface.
+// It allows to convert the map to a driver.value.
+func (m Map) Value() (driver.Value, error) {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+
+	return string(b), nil
+}
+
+// UnmarshalJSON will unmarshall JSON value into
+// the map representation of this value.
+func (m Map) UnmarshalJSON(b []byte) error {
+	var stuff map[string]interface{}
+
+	if err := json.Unmarshal(b, &stuff); err != nil {
+		return err
+	}
+
+	for key, value := range stuff {
+		m[key] = value
+	}
+
+	return nil
+}
+
+// UnmarshalText will unmarshall text value into
+// the map representation of this value.
+func (m Map) UnmarshalText(text []byte) error {
+	if err := json.Unmarshal(text, &m); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

**Description**

This PR adds `map` support to native SQL driver hence allowing to read and write `JSON` and `JSONB` values to and from the databases. 

**Notes for Reviewers**
@kumarabd please make a release if everything looks fine. It will help moving https://github.com/layer5io/meshery/pull/2724 forward.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
