### PR TITLE
Add support for unmarshalling into nested native go maps

### DIFF
--- a/database/sql.go
+++ b/database/sql.go
@@ -45,15 +45,19 @@ func (m Map) Value() (driver.Value, error) {
 
 // UnmarshalJSON will unmarshall JSON value into
 // the map representation of this value.
-func (m Map) UnmarshalJSON(b []byte) error {
+func (m *Map) UnmarshalJSON(b []byte) error {
 	var stuff map[string]interface{}
 
 	if err := json.Unmarshal(b, &stuff); err != nil {
 		return ErrSQLMapUnmarshalJSON(err)
 	}
 
+	if *m == nil {
+		*m = Map{}
+	}
+
 	for key, value := range stuff {
-		m[key] = value
+		(*m)[key] = value
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

**Description**

This PR adds support for unmarshalling into nested native go maps. Previous implementation would fail when a nested map in uninitialized, this implementation takes the possibility of the map being uninitialized and assigns a new `Map` if that's the case in order to fix the issue.

**Notes for Reviewers**
PR https://github.com/layer5io/meshery/pull/2724 has been updated, this PR and a subsequent meshkit release would help finalizing that PR.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
