### PR TITLE
Add OAM types

### DIFF
--- a/models/oam/core/v1alpha1/application_component.go
+++ b/models/oam/core/v1alpha1/application_component.go
@@ -1,0 +1,29 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Component is the structure for the core OAM Application Component
+type Component struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec ComponentSpec `json:"spec,omitempty"`
+}
+
+// ComponentSpec is the structure for the core OAM Application Component Spec
+type ComponentSpec struct {
+	Type       string                 `json:"type"`
+	Settings   map[string]interface{} `json:"settings"`
+	Parameters []ComponentParameter   `json:"parameters"`
+}
+
+// ComponentParameter is the structure for the core OAM Application Component
+// Paramater
+type ComponentParameter struct {
+	Name        string   `json:"name"`
+	FieldPaths  []string `json:"fieldPaths"`
+	Required    *bool    `json:"required,omitempty"`
+	Description *string  `json:"description,omitempty"`
+}

--- a/models/oam/core/v1alpha1/application_configuration.go
+++ b/models/oam/core/v1alpha1/application_configuration.go
@@ -1,0 +1,47 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Configuration is the structure for OAM Application Configuration
+type Configuration struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec ConfigurationSpec `json:"spec,omitempty"`
+}
+
+// ConfigurationSpec is the structure for the OAM Application
+// Configuration Spec
+type ConfigurationSpec struct {
+	Components []ConfigurationSpecComponent
+}
+
+// ConfigurationSpecComponent is the struct for OAM Application
+// Configuration's spec's components
+type ConfigurationSpecComponent struct {
+	ComponentName string
+	Traits        []ConfigurationSpecComponentTrait
+	Scopes        []ConfigurationSpecComponentScope
+}
+
+// ConfigurationSpecComponentTrait is the struct
+type ConfigurationSpecComponentTrait struct {
+	Name       string
+	Properties map[string]interface{}
+}
+
+// ConfigurationSpecComponentScope struct defines the structure
+// for scope of OAM application configuration's spec's component's scope
+type ConfigurationSpecComponentScope struct {
+	ScopeRef ConfigurationSpecComponentScopeRef
+}
+
+// ConfigurationSpecComponentScopeRef struct defines the structure for
+// scope of OAM application configuration's spec's component's scope's
+// scopeRef
+type ConfigurationSpecComponentScopeRef struct {
+	metav1.TypeMeta `json:",inline"`
+	Name            string
+}

--- a/models/oam/core/v1alpha1/core_types.go
+++ b/models/oam/core/v1alpha1/core_types.go
@@ -1,0 +1,7 @@
+package v1alpha1
+
+// DefinitionRef struct describes the structure for DefinitionRef
+// which are used within TraitDefinition, WorkloadDefinition, etc
+type DefinitionRef struct {
+	Name string `json:"name,omitempty"`
+}

--- a/models/oam/core/v1alpha1/doc.go
+++ b/models/oam/core/v1alpha1/doc.go
@@ -1,0 +1,10 @@
+// Package v1alpha1 contains the definitions for OAM
+// core/v1alpha1 objects
+//
+// The definitions include:
+// 1. Component
+// 2. Application Confiuration
+// 3. Trait Definition
+// 4. Workload Definition
+// 5. Scope Definiton
+package v1alpha1

--- a/models/oam/core/v1alpha1/scope_definition.go
+++ b/models/oam/core/v1alpha1/scope_definition.go
@@ -1,0 +1,19 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ScopeDefinition is the struct for OAM ScopeDefinition construct
+type ScopeDefinition struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec ScopeDefinitionSpec
+}
+
+// ScopeDefinitionSpec is the struct for OAM ScopeDefinition's spec
+type ScopeDefinitionSpec struct {
+	AllowComponentOverlap bool          `json:"allowComponentOverlap,omitempty"`
+	DefinitionRef         DefinitionRef `json:"definitionRef,omitempty"`
+}

--- a/models/oam/core/v1alpha1/trait_definition.go
+++ b/models/oam/core/v1alpha1/trait_definition.go
@@ -1,0 +1,20 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TraitDefinition is the struct for OAM TraitDefinition construct
+type TraitDefinition struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec TraitDefinitionSpec `json:"spec,omitempty"`
+}
+
+// TraitDefinitionSpec is the struct for OAM TraitDefinitionSpec's spec
+type TraitDefinitionSpec struct {
+	AppliesToWorkloads []string      `json:"appliesToWorkloads,omitempty"`
+	DefinitionRef      DefinitionRef `json:"definitionRef,omitempty"`
+	RevisionEnabled    bool          `json:"revisionEnabled,omitempty"`
+}

--- a/models/oam/core/v1alpha1/workload_definition.go
+++ b/models/oam/core/v1alpha1/workload_definition.go
@@ -1,0 +1,18 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// WorkloadDefinition is the struct for OAM WorkloadDefinition construct
+type WorkloadDefinition struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec WorkloadDefinitionSpec `json:"spec,omitempty"`
+}
+
+// WorkloadDefinitionSpec is the struct for OAM WorkloadDefinitionSpec's spec
+type WorkloadDefinitionSpec struct {
+	DefinitionRef DefinitionRef `json:"definitionRef,omitempty"`
+}


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

**Description**

This PR fixes #51 
This PR adds OAM core v1alpha1 types into meshkit so that each adapter as well as meshery can use them.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
