### PR TITLE
[CI] error reference publisher for meshkit

### DIFF
--- a/.github/workflows/error-ref-publisher.yaml
+++ b/.github/workflows/error-ref-publisher.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           repository: 'meshery/meshery'
           # token with write access to meshery repository
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
           path: 'meshery'
           ref: 'master'
 
@@ -48,6 +48,6 @@ jobs:
           git config user.name l5io
           git config user.email ci@layer5.io
           git add ./docs/_data/errorref/meshkit_errors_export.json
-          git commit -m "[Docs] update error reference for Meshkit library" --signoff
+          git commit -m "[Docs] update error reference for MeshKit library" --signoff
           git push origin master
           cd ../

--- a/.github/workflows/error-ref-publisher.yaml
+++ b/.github/workflows/error-ref-publisher.yaml
@@ -48,6 +48,6 @@ jobs:
           git config user.name l5io
           git config user.email ci@layer5.io
           git add ./docs/_data/errorref/meshkit_errors_export.json
-          git commit -m "[Docs] update error reference for MeshKit library" --signoff
+          git commit -m "[Docs] Error Code Reference: Updated codes for MeshKit library" --signoff
           git push origin master
           cd ../

--- a/.github/workflows/error-ref-publisher.yaml
+++ b/.github/workflows/error-ref-publisher.yaml
@@ -1,4 +1,4 @@
-name: Error Reference Publisher
+name: Error Code Reference Publisher
 on:
   push:
     branches:

--- a/.github/workflows/error-ref-publisher.yaml
+++ b/.github/workflows/error-ref-publisher.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Run utility
         run: |
-          go run github.com/layer5io/meshkit/cmd/errorutil -d . analyze --skip-dirs meshery
+          make errorutil-analyze
 
       # to update errorutil* files in meshkit repo
       - name: Commit changes
@@ -33,9 +33,11 @@ jobs:
       - name: Checkout meshery
         uses: actions/checkout@v2
         with:
-          repository: 'DelusionalOptimist/meshery'
+          repository: 'layer5io/meshery'
+          # token with write access to meshery repository
           token: ${{ secrets.PAT }}
           path: 'meshery'
+          ref: 'master'
 
       # to push changes to meshery docs
       - name: Update and push docs

--- a/.github/workflows/error-ref-publisher.yaml
+++ b/.github/workflows/error-ref-publisher.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout meshery
         uses: actions/checkout@v2
         with:
-          repository: 'layer5io/meshery'
+          repository: 'meshery/meshery'
           # token with write access to meshery repository
           token: ${{ secrets.PAT }}
           path: 'meshery'

--- a/.github/workflows/error-ref-publisher.yaml
+++ b/.github/workflows/error-ref-publisher.yaml
@@ -1,0 +1,36 @@
+name: Error Reference Publisher
+on:
+  push:
+    branches:
+      - 'err-ref-ci'
+
+jobs:
+  error-ref:
+    name: Error codes utility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ secrets.GO_VERSION }}
+
+      - name: Checkout meshery
+        uses: actions/checkout@v2
+        with:
+          repository: 'DelusionalOptimist/meshery'
+          token: ${{ secrets.PAT }}
+          path: 'meshery'
+
+      - name: Update and push docs
+        run: |
+          go run github.com/layer5io/meshkit/cmd/errorutil -d . update --skip-dirs meshery
+          echo '{ "errors_export": '$(cat errorutil_errors_export.json)' }' | jq > ./meshery/docs/_data/errorref/meshkit_errors_export.json
+
+          cd ./meshery
+          git config user.name l5io
+          git config user.email ci@layer5.io
+          git add ./docs/_data/errorref/meshkit_errors_export.json
+          git commit -m "[Docs] update error reference for Meshkit library" --signoff
+          git push origin master

--- a/.github/workflows/error-ref-publisher.yaml
+++ b/.github/workflows/error-ref-publisher.yaml
@@ -16,6 +16,20 @@ jobs:
         with:
           go-version: ${{ secrets.GO_VERSION }}
 
+      - name: Run utility
+        run: |
+          go run github.com/layer5io/meshkit/cmd/errorutil -d . analyze --skip-dirs meshery
+
+      # to update errorutil* files in meshkit repo
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_user_name: l5io
+          commit_user_email: ci@layer5.io
+          commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          commit_options: '--signoff'
+          commit_message: "run error codes utility"
+
       - name: Checkout meshery
         uses: actions/checkout@v2
         with:
@@ -23,9 +37,9 @@ jobs:
           token: ${{ secrets.PAT }}
           path: 'meshery'
 
+      # to push changes to meshery docs
       - name: Update and push docs
         run: |
-          go run github.com/layer5io/meshkit/cmd/errorutil -d . update --skip-dirs meshery
           echo '{ "errors_export": '$(cat errorutil_errors_export.json)' }' | jq > ./meshery/docs/_data/errorref/meshkit_errors_export.json
 
           cd ./meshery
@@ -34,3 +48,4 @@ jobs:
           git add ./docs/_data/errorref/meshkit_errors_export.json
           git commit -m "[Docs] update error reference for Meshkit library" --signoff
           git push origin master
+          cd ../

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ test: error
 	go test ./...
 
 errorutil:
-	go run github.com/layer5io/meshkit/cmd/errorutil -d . update
+	go run github.com/layer5io/meshkit/cmd/errorutil -d . update --skip-dirs meshery
 
 errorutil-analyze:
-	go run github.com/layer5io/meshkit/cmd/errorutil -d . analyze
+	go run github.com/layer5io/meshkit/cmd/errorutil -d . analyze --skip-dirs meshery
 
 build-errorutil:
 	go build -o errorutil cmd/errorutil/main.go

--- a/errorutil_analyze_errors.json
+++ b/errorutil_analyze_errors.json
@@ -121,6 +121,14 @@
       "path": "database/error.go"
     },
     {
+      "name": "ErrControllerCode",
+      "old_code": "test",
+      "code": "test",
+      "code_is_literal": true,
+      "code_is_int": false,
+      "path": "logger/controller.go"
+    },
+    {
       "name": "ErrUnmarshalCode",
       "old_code": "11043",
       "code": "11043",
@@ -1111,6 +1119,16 @@
         "code_is_int": true,
         "path": "utils/kubernetes/expose/error.go"
       }
+    ],
+    "test": [
+      {
+        "name": "ErrControllerCode",
+        "old_code": "test",
+        "code": "test",
+        "code_is_literal": true,
+        "code_is_int": false,
+        "path": "logger/controller.go"
+      }
     ]
   },
   "call_expr_codes": [],
@@ -1163,6 +1181,17 @@
     "ErrConstructingRestHelperCode": [
       {
         "name": "ErrConstructingRestHelperCode",
+        "code": "",
+        "severity": "Alert",
+        "long_description": "",
+        "short_description": "",
+        "probable_cause": "",
+        "suggested_remediation": ""
+      }
+    ],
+    "ErrControllerCode": [
+      {
+        "name": "ErrControllerCode",
         "code": "",
         "severity": "Alert",
         "long_description": "",


### PR DESCRIPTION
Signed-off-by: Rudraksh Pareek <rudrakshpareek3601@gmail.com>

**Description**
Integrating the error codes utility into meshkit's CI.
Also see https://github.com/layer5io/meshery/pull/3296
This PR fixes #

**Notes for Reviewers**
* Runs error codes utility on every commit to the master branch.
* Updates the files generated by it in this repo.
* Updates meshery docs and pushes them to meshery repo.

*Commit e8a3f5f is just for demo*

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
