### PR TITLE
minor improvements

### DIFF
--- a/logger/controller.go
+++ b/logger/controller.go
@@ -2,8 +2,17 @@ package logger
 
 import (
 	"github.com/go-logr/logr"
+	"github.com/layer5io/meshkit/errors"
 	"github.com/sirupsen/logrus"
 )
+
+var (
+	ErrControllerCode = "test"
+)
+
+func ErrController(err error, msg string) error {
+	return errors.New(ErrControllerCode, errors.Alert, []string{msg}, []string{err.Error()}, []string{}, []string{})
+}
 
 type Controller struct {
 	enabled bool
@@ -26,7 +35,7 @@ func (c *Controller) Info(msg string, keysAndValues ...interface{}) {
 }
 
 func (c *Controller) Error(err error, msg string, keysAndValues ...interface{}) {
-	c.base.Error(err)
+	c.base.Error(ErrController(err, msg))
 }
 
 func (c *Controller) V(level int) logr.InfoLogger {


### PR DESCRIPTION
Signed-off-by: kumarabd <abishekkumar92@gmail.com>

**Description**

- In minikube clusters, if service ClusterIP is the same as that of the LoadBalancer IP, ClusterIP is used for connecting to the cluster along with the application port.
- Controller logger supports printing meshkit error objects

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
