### PR TITLE
fix: Combined same types of function params

### DIFF
--- a/cmd/errorutil/internal/coder/commands.go
+++ b/cmd/errorutil/internal/coder/commands.go
@@ -64,7 +64,7 @@ func getGlobalFlags(cmd *cobra.Command) (globalFlags, error) {
 	return flags, nil
 }
 
-func walkSummarizeExport(globalFlags globalFlags, update bool, updateAll bool) error {
+func walkSummarizeExport(globalFlags globalFlags, update, updateAll bool) error {
 	config.Logging(globalFlags.verbose)
 	errorsInfo := mesherr.NewInfoAll()
 	err := walk(globalFlags, update, updateAll, errorsInfo)

--- a/cmd/errorutil/internal/coder/file.go
+++ b/cmd/errorutil/internal/coder/file.go
@@ -2,9 +2,6 @@ package coder
 
 import (
 	"bytes"
-	"github.com/layer5io/meshkit/cmd/errorutil/internal/component"
-	errutilerr "github.com/layer5io/meshkit/cmd/errorutil/internal/error"
-	"github.com/sirupsen/logrus"
 	"go/ast"
 	"go/format"
 	"go/parser"
@@ -12,9 +9,13 @@ import (
 	"io/ioutil"
 	"regexp"
 	"strconv"
+
+	"github.com/layer5io/meshkit/cmd/errorutil/internal/component"
+	errutilerr "github.com/layer5io/meshkit/cmd/errorutil/internal/error"
+	"github.com/sirupsen/logrus"
 )
 
-func handleFile(path string, update bool, updateAll bool, infoAll *errutilerr.InfoAll, comp *component.Info) error {
+func handleFile(path string, update, updateAll bool, infoAll *errutilerr.InfoAll, comp *component.Info) error {
 	logger := logrus.WithFields(logrus.Fields{"path": path})
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)

--- a/cmd/errorutil/internal/coder/node.go
+++ b/cmd/errorutil/internal/coder/node.go
@@ -2,10 +2,11 @@ package coder
 
 import (
 	"fmt"
-	"github.com/layer5io/meshkit/cmd/errorutil/internal/component"
-	"github.com/sirupsen/logrus"
 	"go/ast"
 	"strings"
+
+	"github.com/layer5io/meshkit/cmd/errorutil/internal/component"
+	"github.com/sirupsen/logrus"
 
 	errutilerr "github.com/layer5io/meshkit/cmd/errorutil/internal/error"
 )
@@ -116,7 +117,7 @@ func isNewCallExpr(node ast.Node) (*errutilerr.Error, bool) {
 }
 
 // handleValueSpec inspects node n if it is a ValueSpec, analyses and updates it (depending on update and updateAll). Returns true if any value was changed.
-func handleValueSpec(n ast.Node, update bool, updateAll bool, comp *component.Info, logger *logrus.Entry, path string, infoAll *errutilerr.InfoAll) bool {
+func handleValueSpec(n ast.Node, update, updateAll bool, comp *component.Info, logger *logrus.Entry, path string, infoAll *errutilerr.InfoAll) bool {
 	anyValueChanged := false
 	spec, ok := n.(*ast.ValueSpec)
 	if ok {

--- a/cmd/errorutil/internal/coder/path.go
+++ b/cmd/errorutil/internal/coder/path.go
@@ -21,7 +21,7 @@ func contains(s []string, str string) bool {
 	return false
 }
 
-func walk(globalFlags globalFlags, update bool, updateAll bool, errorsInfo *mesherr.InfoAll) error {
+func walk(globalFlags globalFlags, update, updateAll bool, errorsInfo *mesherr.InfoAll) error {
 	subDirsToSkip := append([]string{".git", ".github"}, globalFlags.skipDirs...)
 	logrus.Info(fmt.Sprintf("root directory: %s", globalFlags.rootDir))
 	logrus.Info(fmt.Sprintf("output directory: %s", globalFlags.outDir))

--- a/config/provider/inmem.go
+++ b/config/provider/inmem.go
@@ -37,7 +37,7 @@ func NewInMem(opts Options) (config.Handler, error) {
 // -------------------------------------------Application config methods----------------------------------------------------------------
 
 // SetKey sets a key value in local store
-func (l *InMem) SetKey(key string, value string) {
+func (l *InMem) SetKey(key, value string) {
 	l.mutex.Lock()
 	l.store[key] = value
 	l.mutex.Unlock()

--- a/config/provider/viper.go
+++ b/config/provider/viper.go
@@ -62,7 +62,7 @@ func NewViper(opts Options) (config.Handler, error) {
 	}, nil
 }
 
-func (v *Viper) SetKey(key string, value string) {
+func (v *Viper) SetKey(key, value string) {
 	v.mutex.Lock()
 	v.instance.Set(key, value)
 	_ = v.instance.WriteConfig()

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -15,7 +15,7 @@ func NewDefault(code string, ldescription ...string) *Error {
 	}
 }
 
-func New(code string, severity Severity, sdescription []string, ldescription []string, probablecause []string, remedy []string) *Error {
+func New(code string, severity Severity, sdescription, ldescription, probablecause, remedy []string) *Error {
 
 	return &Error{
 		Code:                 code,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -75,7 +75,7 @@ func Filepath() string {
 	return fmt.Sprintf("file: %s, line: %d", fn, line)
 }
 
-func DownloadFile(filepath string, url string) error {
+func DownloadFile(filepath, url string) error {
 
 	// Get the data
 	resp, err := http.Get(url)
@@ -104,7 +104,7 @@ func GetHome() string {
 
 // CreateFile creates a file with the given content on the given location with
 // the given filename
-func CreateFile(contents []byte, filename string, location string) error {
+func CreateFile(contents []byte, filename, location string) error {
 	// Create file in -rw-r--r-- mode
 	fd, err := os.OpenFile(filepath.Join(location, filename), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {


### PR DESCRIPTION
## Description

If parameters of the same type lie consecutively, mention their type once at the end of the last parameter. Unlike other languages, like C, where all parameters must be specified with types explicitly, it is not required to do so in Go. Combining the types is usually recommended for the sake of brevity.
