### PR TITLE
Add native support for appversion to chartversion mappings and support local helm charts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.8.1
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	gorm.io/driver/sqlite v1.1.4
 	gorm.io/gorm v1.20.10
 	helm.sh/helm/v3 v3.3.1

--- a/utils/kubernetes/error.go
+++ b/utils/kubernetes/error.go
@@ -1,6 +1,10 @@
 package kubernetes
 
-import "github.com/layer5io/meshkit/errors"
+import (
+	"fmt"
+
+	"github.com/layer5io/meshkit/errors"
+)
 
 var (
 	ErrApplyManifestCode    = "11021"
@@ -14,6 +18,21 @@ var (
 	ErrInvalidAPIServerCode = "11029"
 	ErrLoadConfigCode       = "11030"
 	ErrValidateConfigCode   = "11031"
+	// ErrCreatingHelmIndexCode represents the errors which are generated
+	// during creation of helm index
+	ErrCreatingHelmIndexCode = "11032"
+
+	// ErrEntryWithAppVersionNotExistsCode represents the error which is generated
+	// when no entry is found with specified name and app version
+	ErrEntryWithAppVersionNotExistsCode = "11033"
+
+	// ErrHelmRepositoryNotFoundCode represents the error which is generated when
+	// no valid helm repository is found
+	ErrHelmRepositoryNotFoundCode = "11034"
+
+	// ErrDecodeYamlCode represents the error which is generated when yaml
+	// decode process fails
+	ErrDecodeYamlCode = "11035"
 
 	ErrEndpointNotFound = errors.New(ErrEndpointNotFoundCode, errors.Alert, []string{"Unable to discover an endpoint"}, []string{}, []string{}, []string{})
 	ErrInvalidAPIServer = errors.New(ErrInvalidAPIServerCode, errors.Alert, []string{"Invalid API Server URL"}, []string{}, []string{}, []string{})
@@ -61,4 +80,24 @@ func ErrLoadConfig(err error) error {
 // ErrValidateConfig is the error which occurs in the process of validating a kubernetes config
 func ErrValidateConfig(err error) error {
 	return errors.New(ErrValidateConfigCode, errors.Alert, []string{"Validation failed in the kubernetes config"}, []string{err.Error()}, []string{"Kubernetes config is not accessible to meshery or not valid"}, []string{"Upload your kubernetes config via the settings dashboard. If uploaded, wait for a minute for it to get initialized"})
+}
+
+// ErrCreatingHelmIndex is the error for creating helm index
+func ErrCreatingHelmIndex(err error) error {
+	return errors.New(ErrCreatingHelmIndexCode, errors.Alert, []string{"Error while creating Helm Index"}, []string{err.Error()}, []string{}, []string{})
+}
+
+// ErrEntryWithAppVersionNotExists is the error when an entry with the given app version is not found
+func ErrEntryWithAppVersionNotExists(entry, appVersion string) error {
+	return errors.New(ErrEntryWithAppVersionNotExistsCode, errors.Alert, []string{"Entry for the app version does not exist"}, []string{fmt.Sprintf("entry %s with app version %s does not exists", entry, appVersion)}, []string{}, []string{})
+}
+
+// ErrHelmRepositoryNotFound is the error when no valid remote helm repository is found
+func ErrHelmRepositoryNotFound(repo string, err error) error {
+	return errors.New(ErrHelmRepositoryNotFoundCode, errors.Alert, []string{"Helm repo not found"}, []string{fmt.Sprintf("either the repo %s does not exists or is corrupt: %v", repo, err)}, []string{}, []string{})
+}
+
+// ErrDecodeYaml is the error when the yaml unmarshal fails
+func ErrDecodeYaml(err error) error {
+	return errors.New(ErrDecodeYamlCode, errors.Alert, []string{"Error occured while decoding YAML"}, []string{err.Error()}, []string{}, []string{})
 }


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

**Description**
This PR adds support for Add native support for appversion to chartversion mappings and support local helm charts.

- User can give app version of and it will be automatically be converted into chart version (provided that a valid Helm Repository exists to perform such mappings).
- User can also give `LocalPath` of the chart (in .tgz or .tar.gz or untarred format), in this case this local chart will be used for installation and both URL and ChartLocation attributes will be completely ignored.
- Add `DryRun` for easier testing
- Add `Logger` for logging within the function, helpful for debugging

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
