### PR TITLE
[Broadcast] Apply design spec for notification to broadcast

### DIFF
--- a/utils/broadcast/broadcaster.go
+++ b/utils/broadcast/broadcaster.go
@@ -8,16 +8,25 @@ which subscribers Register to pick up those messages.
 */
 package broadcast
 
-type BroadcastType string
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type BroadcastSource string
 
 const (
 	// OperatorSyncChannel is a broadcast channel type for operator status messages.
-	OperatorSyncChannel BroadcastType = "operator-sync"
+	OperatorSyncChannel BroadcastSource = "urn:meshery:operator:sync"
 )
 
 type BroadcastMessage struct {
-	Type    BroadcastType
-	Message interface{}
+	Id     uuid.UUID
+	Source BroadcastSource
+	Type   string
+	Data   *interface{}
+	Time   time.Time
 }
 
 type broadcaster struct {


### PR DESCRIPTION
Signed-off-by: Bariq <bariqhibat@gmail.com>

**Description**

Apply some of the fields from the design spec notification to broadcast. Should be backward compatible.

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
