### PR TITLE
Adding few extra checks in component generation

### DIFF
--- a/utils/manifests/error.go
+++ b/utils/manifests/error.go
@@ -8,6 +8,7 @@ const (
 	ErrGetAPIVersionCode  = "1003"
 	ErrGetAPIGroupCode    = "1004"
 	ErrPopulatingYamlCode = "1005"
+	ErrAbsentFilterCode   = "1006"
 )
 
 func ErrGetCrdNames(err error) error {
@@ -26,4 +27,7 @@ func ErrGetAPIGroup(err error) error {
 
 func ErrPopulatingYaml(err error) error {
 	return errors.New(ErrPopulatingYamlCode, errors.Alert, []string{"Error populating yaml"}, []string{err.Error()}, []string{"Yaml could not be populated with the returned manifests"}, []string{""})
+}
+func ErrAbsentFilter(err error) error {
+	return errors.New(ErrAbsentFilterCode, errors.Alert, []string{"Error with passed filters"}, []string{err.Error()}, []string{"ItrFilter or ItrSpecFilter is either not passed or empty"}, []string{"Pass the correct ItrFilter and ItrSpecFilter"})
 }

--- a/utils/manifests/utils.go
+++ b/utils/manifests/utils.go
@@ -65,7 +65,7 @@ func getDefinitions(crd string, resource int, cfg Config, filepath string, binPa
 
 func getSchema(crd string, fp string, binPath string, cfg Config) (string, error) {
 	//few checks to avoid index out of bound panic
-	if len(cfg.Filter.ItrFilter) == 0 {
+	if len(cfg.Filter.ItrSpecFilter) == 0 {
 		return "", ErrAbsentFilter(errors.New("Empty ItrSpecFilter"))
 	}
 	inputFormat := "yaml"

--- a/utils/manifests/utils.go
+++ b/utils/manifests/utils.go
@@ -3,6 +3,7 @@ package manifests
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -63,6 +64,10 @@ func getDefinitions(crd string, resource int, cfg Config, filepath string, binPa
 }
 
 func getSchema(crd string, fp string, binPath string, cfg Config) (string, error) {
+	//few checks to avoid index out of bound panic
+	if len(cfg.Filter.ItrFilter) == 0 {
+		return "", ErrAbsentFilter(errors.New("Empty ItrSpecFilter"))
+	}
 	inputFormat := "yaml"
 	if cfg.Filter.IsJson {
 		inputFormat = "json"
@@ -165,6 +170,11 @@ func getCrdnames(s string) []string {
 }
 
 func getApiVersion(binPath string, fp string, crd string, inputFormat string, cfg Config) (string, error) {
+	//few checks to avoid index out of bound panic
+	if len(cfg.Filter.ItrFilter) == 0 {
+		return "", ErrAbsentFilter(errors.New("Empty ItrFilter"))
+	}
+
 	var (
 		out bytes.Buffer
 		er  bytes.Buffer
@@ -199,6 +209,10 @@ func getApiVersion(binPath string, fp string, crd string, inputFormat string, cf
 	return s, nil
 }
 func getApiGrp(binPath string, fp string, crd string, inputFormat string, cfg Config) (string, error) {
+	//few checks to avoid index out of bound panic
+	if len(cfg.Filter.ItrFilter) == 0 {
+		return "", ErrAbsentFilter(errors.New("Empty ItrFilter"))
+	}
 	var (
 		out bytes.Buffer
 		er  bytes.Buffer


### PR DESCRIPTION
**Description**

Currenly if ItrFilter or ItrSpecFilter is not passed in config, the adapter will panic. 
Instead we should handle that case and return an error.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
