### PR TITLE
[NATS] handling exec sessions in broker

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -1,5 +1,7 @@
 package broker
 
+import "github.com/nats-io/nats.go"
+
 var (
 	NotConnected = "not-connected"
 )
@@ -10,15 +12,22 @@ type PublishInterface interface {
 }
 
 type SubscribeInterface interface {
-	Subscribe(string, string, []byte) error
-	SubscribeWithChannel(string, string, chan *Message) error
+	Subscribe(string, string, string, []byte) (*nats.Subscription, error)
+	SubscribeWithChannel(string, string, string, chan *Message) (*nats.Subscription, error)
+}
+
+type ExecInterface interface {
+	GetActiveExecSessions() []*string
+	GetExecSession(string) *ExecProp
 }
 
 type Handler interface {
 	PublishInterface
 	SubscribeInterface
+	ExecInterface
 	Info() string
 	DeepCopyObject() Handler
 	DeepCopyInto(Handler)
 	IsEmpty() bool
+	Close(string) bool
 }

--- a/broker/messaging.go
+++ b/broker/messaging.go
@@ -1,5 +1,7 @@
 package broker
 
+import "github.com/nats-io/nats.go"
+
 var (
 	Request          ObjectType = "request-payload"
 	MeshSync         ObjectType = "meshsync-data"
@@ -34,4 +36,10 @@ type Message struct {
 type RequestObject struct {
 	Entity  RequestEntity
 	Payload interface{}
+}
+
+type ExecProp struct {
+	ID             string
+	ReceiveChannel chan *Message
+	Subscription   *nats.Subscription
 }


### PR DESCRIPTION
Signed-off-by: Bariq <bariqhibat@gmail.com>

**Description**

Exec sessions are handled within Meshery Extensions level before. Here, we want to leverage the exec sessions to Meshkit-level and provide more handlers and functionalities.

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
