### PR TITLE
Moved getlatestreleasetag function to meshkit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/nats-io/nats.go v1.9.1
 	github.com/onsi/ginkgo v1.14.1 // indirect
 	github.com/onsi/gomega v1.10.2 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.8.1

--- a/utils/error.go
+++ b/utils/error.go
@@ -20,8 +20,8 @@ var (
 	ErrRemoteFileNotFoundCode        = "11052"
 	ErrReadingRemoteFileCode         = "11053"
 	ErrReadingLocalFileCode          = "11054"
-
-	ErrInvalidProtocol = errors.New(ErrInvalidProtocolCode, errors.Alert, []string{"invalid protocol: only http, https and file are valid protocols"}, []string{}, []string{"Network protocol is incorrect"}, []string{"Make sure to specify the right network protocol"})
+	ErrGettingLatestReleaseTagCode   = "11055"
+	ErrInvalidProtocol               = errors.New(ErrInvalidProtocolCode, errors.Alert, []string{"invalid protocol: only http, https and file are valid protocols"}, []string{}, []string{"Network protocol is incorrect"}, []string{"Make sure to specify the right network protocol"})
 )
 
 func ErrUnmarshal(err error) error {
@@ -66,4 +66,8 @@ func ErrReadingRemoteFile(err error) error {
 
 func ErrReadingLocalFile(err error) error {
 	return errors.New(ErrReadingLocalFileCode, errors.Alert, []string{"error reading local file"}, []string{err.Error()}, []string{"File doesnt exist in the location", "File name is incorrect"}, []string{"Make sure to input the right file name and location"})
+}
+
+func ErrGettingLatestReleaseTag(err error) error {
+	return errors.New(ErrGettingLatestReleaseTagCode, errors.Alert, []string{"Could not fetch latest stable release from github"}, []string{err.Error()}, []string{"Failed to make GET request to github", "Invalid response recieved on github.com/<org>/<repo>/releases/stable"}, []string{"Make sure Github is reachable", "Make sure a valid response is available on github.com/<org>/<repo>/releases/stable"})
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -10,9 +10,13 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 // unmarshal returns parses the JSON config data and stores the value in the reference to result
@@ -181,4 +185,35 @@ func ReadLocalFile(location string) (string, error) {
 	}
 
 	return string(data), nil
+}
+
+// Gets the latest stable release tag from github for a given org name and repo name(in that org)
+func GetLatestReleaseTag(org string, repo string) (string, error) {
+	var url string = "https://github.com/" + org + "/" + repo + "/releases/latest"
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to make GET request to %s", url)
+	}
+	defer safeClose(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.New("failed to get latest stable release tag")
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read response body")
+	}
+	re := regexp.MustCompile("/releases/tag/(.*?)\"")
+	releases := re.FindAllString(string(body), -1)
+	latest := strings.ReplaceAll(releases[0], "/releases/tag/", "")
+	latest = strings.ReplaceAll(latest, "\"", "")
+	return latest, nil
+}
+
+// SafeClose is a helper function help to close the io
+func safeClose(co io.Closer) {
+	if cerr := co.Close(); cerr != nil {
+		log.Error(cerr)
+	}
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -15,7 +15,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -192,17 +191,17 @@ func GetLatestReleaseTag(org string, repo string) (string, error) {
 	var url string = "https://github.com/" + org + "/" + repo + "/releases/latest"
 	resp, err := http.Get(url)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to make GET request to %s", url)
+		return "", ErrGettingLatestReleaseTag(err)
 	}
 	defer safeClose(resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
-		return "", errors.New("failed to get latest stable release tag")
+		return "", ErrGettingLatestReleaseTag(err)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to read response body")
+		return "", ErrGettingLatestReleaseTag(err)
 	}
 	re := regexp.MustCompile("/releases/tag/(.*?)\"")
 	releases := re.FindAllString(string(body), -1)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -205,6 +206,9 @@ func GetLatestReleaseTag(org string, repo string) (string, error) {
 	}
 	re := regexp.MustCompile("/releases/tag/(.*?)\"")
 	releases := re.FindAllString(string(body), -1)
+	if len(releases) == 0 {
+		return "", ErrGettingLatestReleaseTag(errors.New("no release found in this repository"))
+	}
 	latest := strings.ReplaceAll(releases[0], "/releases/tag/", "")
 	latest = strings.ReplaceAll(latest, "\"", "")
 	return latest, nil


### PR DESCRIPTION
Signed-off-by: ashish <ashishjaitiwari15112000@gmail.com>

**Description**

This PR fixes #131 
This function can be used across meshery and all the adapters in order to remove  api.github.com calls
**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
