### PR TITLE
Add utility function for sorting un-normalized semantic versioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/nats-io/nats.go v1.9.1
 	github.com/onsi/ginkgo v1.14.1 // indirect
 	github.com/onsi/gomega v1.10.2 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.8.1

--- a/utils/sortversions.go
+++ b/utils/sortversions.go
@@ -1,0 +1,61 @@
+package utils
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type dottedStrings []string
+
+func (d dottedStrings) Less(i, j int) bool {
+	si := d[i]
+	sj := d[j]
+	si = cleanup(si)
+	sj = cleanup(sj)
+	siarr := strings.Split(si, ".")
+	sjarr := strings.Split(sj, ".")
+	var n int
+	if len(siarr) < len(sjarr) {
+		n = len(siarr)
+		sjarr = sjarr[0:n]
+	} else {
+		n = len(sjarr)
+		siarr = siarr[0:n]
+	}
+	for i := 0; i < n; i++ {
+		p, _ := strconv.Atoi(siarr[i])
+		q, _ := strconv.Atoi(sjarr[i])
+		if p < q {
+			return true
+		}
+		if q < p {
+			return false
+		}
+	}
+	return false
+}
+
+func (d dottedStrings) Len() int {
+	return len(d)
+}
+func (d dottedStrings) Swap(i, j int) {
+	d[i], d[j] = d[j], d[i]
+}
+func cleanup(s string) string {
+	s1 := ""
+	for _, s := range s {
+		if (s >= 48 && s <= 57) || s == 46 {
+			s1 += string(s)
+		}
+	}
+	return s1
+}
+
+//SortDottedStringsByDigits takes version-like dot seperated digits in string format and returns them in sorted normalized form.
+// Takes [v1.4.3,0.9.3,v0.0.0]=> returns [v0.0.0,0.9.3,v1.4.3]
+func SortDottedStringsByDigits(s []string) []string {
+	s1 := dottedStrings(s)
+	sort.Sort(s1)
+	return s1
+}

--- a/utils/sortversions.go
+++ b/utils/sortversions.go
@@ -16,10 +16,8 @@ func (d dottedStrings) Less(i, j int) bool {
 	var n int
 	if len(siarr) < len(sjarr) {
 		n = len(siarr)
-		sjarr = sjarr[0:n]
 	} else {
 		n = len(sjarr)
-		siarr = siarr[0:n]
 	}
 	// While comparing two strings, the comparison is made upto the size of smaller string
 	for i := 0; i < n; i++ {
@@ -33,7 +31,13 @@ func (d dottedStrings) Less(i, j int) bool {
 			return false
 		}
 	}
-	return false
+
+	//If both strings are equal to the len of smallest string, consider the smaller-length string to be greater in value.
+	// This is to make sure that , while comparing strings like, 1.0.0 and 1.0.0-someprefix, 1.0.0 is considered greater
+	if len(siarr) < len(sjarr) {
+		return false
+	}
+	return true
 }
 
 func (d dottedStrings) Len() int {
@@ -43,6 +47,10 @@ func (d dottedStrings) Swap(i, j int) {
 	d[i], d[j] = d[j], d[i]
 }
 func cleanup(s string) string {
+	s = strings.Replace(s, "alpha", ".0", -1)
+	s = strings.Replace(s, "beta", ".1", -1)
+	s = strings.Replace(s, "rc", ".2", -1)
+	s = strings.Replace(s, "stable", ".3", -1)
 	s1 := ""
 	for _, s := range s {
 		if (s >= 48 && s <= 57) || s == 46 {
@@ -54,6 +62,9 @@ func cleanup(s string) string {
 
 //SortDottedStringsByDigits takes version-like dot seperated digits in string format and returns them in sorted normalized form.
 // Takes [v1.4.3,0.9.3,v0.0.0]=> returns [v0.0.0,0.9.3,v1.4.3]
+// This function ignores all letters except for:
+// - numeric digits
+// - alpha, beta, rc, stable
 func SortDottedStringsByDigits(s []string) []string {
 	s1 := dottedStrings(s)
 	sort.Sort(s1)

--- a/utils/sortversions.go
+++ b/utils/sortversions.go
@@ -13,14 +13,22 @@ func (d dottedStrings) Less(i, j int) bool {
 	sj := cleanup(d[j])
 	siarr := strings.Split(si, ".")
 	sjarr := strings.Split(sj, ".")
-	var n int
-	if len(siarr) < len(sjarr) {
-		n = len(siarr)
+	diff := len(siarr) - len(sjarr)
+
+	//Making boths strings the same length
+	if diff > 0 {
+		for diff != 0 {
+			sjarr = append(sjarr, "3")
+			diff--
+		}
 	} else {
-		n = len(sjarr)
+		for diff != 0 {
+			siarr = append(siarr, "3")
+			diff++
+		}
 	}
-	// While comparing two strings, the comparison is made upto the size of smaller string
-	for i := 0; i < n; i++ {
+	// The string will both be the same length
+	for i := range siarr {
 		//We can be sure that siarr and sjarr are numeric string array, hence Atoi can be safely used
 		p, _ := strconv.Atoi(siarr[i])
 		q, _ := strconv.Atoi(sjarr[i])
@@ -31,13 +39,7 @@ func (d dottedStrings) Less(i, j int) bool {
 			return false
 		}
 	}
-
-	//If both strings are equal to the len of smallest string, consider the smaller-length string to be greater in value.
-	// This is to make sure that , while comparing strings like, 1.0.0 and 1.0.0-someprefix, 1.0.0 is considered greater
-	// if len(siarr) < len(sjarr) {
-	// 	return false
-	// }
-	return len(siarr) >= len(sjarr)
+	return false
 }
 
 func (d dottedStrings) Len() int {
@@ -47,10 +49,14 @@ func (d dottedStrings) Swap(i, j int) {
 	d[i], d[j] = d[j], d[i]
 }
 func cleanup(s string) string {
+	if strings.HasPrefix(s, "stable") {
+		s = strings.TrimPrefix(s, "stable")
+		s += "stable"
+	}
 	s = strings.Replace(s, "alpha", ".0", -1)
 	s = strings.Replace(s, "beta", ".1", -1)
 	s = strings.Replace(s, "rc", ".2", -1)
-	s = strings.Replace(s, "stable", ".3", -1)
+	s = strings.Replace(s, "stable", ".4", -1)
 	s1 := ""
 	for _, s := range s {
 		if (s >= 48 && s <= 57) || s == 46 {
@@ -65,6 +71,7 @@ func cleanup(s string) string {
 // This function ignores all letters except for:
 // - numeric digits
 // - alpha, beta, rc, stable
+// For the same version, stable is preferred over edge
 func SortDottedStringsByDigits(s []string) []string {
 	s1 := dottedStrings(s)
 	sort.Sort(s1)

--- a/utils/sortversions.go
+++ b/utils/sortversions.go
@@ -24,6 +24,7 @@ func (d dottedStrings) Less(i, j int) bool {
 		siarr = siarr[0:n]
 	}
 	for i := 0; i < n; i++ {
+		//We can be sure that siarr and sjarr are numeric string array, hence Atoi can be safely used
 		p, _ := strconv.Atoi(siarr[i])
 		q, _ := strconv.Atoi(sjarr[i])
 		if p < q {

--- a/utils/sortversions.go
+++ b/utils/sortversions.go
@@ -9,10 +9,8 @@ import (
 type dottedStrings []string
 
 func (d dottedStrings) Less(i, j int) bool {
-	si := d[i]
-	sj := d[j]
-	si = cleanup(si)
-	sj = cleanup(sj)
+	si := cleanup(d[i])
+	sj := cleanup(d[j])
 	siarr := strings.Split(si, ".")
 	sjarr := strings.Split(sj, ".")
 	var n int
@@ -23,6 +21,7 @@ func (d dottedStrings) Less(i, j int) bool {
 		n = len(sjarr)
 		siarr = siarr[0:n]
 	}
+	// While comparing two strings, the comparison is made upto the size of smaller string
 	for i := 0; i < n; i++ {
 		//We can be sure that siarr and sjarr are numeric string array, hence Atoi can be safely used
 		p, _ := strconv.Atoi(siarr[i])

--- a/utils/sortversions.go
+++ b/utils/sortversions.go
@@ -34,10 +34,10 @@ func (d dottedStrings) Less(i, j int) bool {
 
 	//If both strings are equal to the len of smallest string, consider the smaller-length string to be greater in value.
 	// This is to make sure that , while comparing strings like, 1.0.0 and 1.0.0-someprefix, 1.0.0 is considered greater
-	if len(siarr) < len(sjarr) {
-		return false
-	}
-	return true
+	// if len(siarr) < len(sjarr) {
+	// 	return false
+	// }
+	return len(siarr) >= len(sjarr)
 }
 
 func (d dottedStrings) Len() int {

--- a/utils/sortversions_test.go
+++ b/utils/sortversions_test.go
@@ -36,6 +36,10 @@ var testcases = []TestCases{
 		PassedArray:   []string{"v1.0.0-stable", "0.9.8", "1.0.0-alpha.1", "v1.0.0-alpha"},
 		ExpectedArray: []string{"0.9.8", "1.0.0-alpha.1", "v1.0.0-alpha", "v1.0.0-stable"},
 	},
+	{
+		PassedArray:   []string{"1.0.0", "stable-1.0.0"},
+		ExpectedArray: []string{"1.0.0", "stable-1.0.0"},
+	},
 }
 
 func TestSort(t *testing.T) {

--- a/utils/sortversions_test.go
+++ b/utils/sortversions_test.go
@@ -40,6 +40,22 @@ var testcases = []TestCases{
 		PassedArray:   []string{"1.0.0", "stable-1.0.0"},
 		ExpectedArray: []string{"1.0.0", "stable-1.0.0"},
 	},
+	{
+		PassedArray:   []string{"v1.12.0-rc.1", "1.12.0-beta.2", "1.12.0-beta.1"},
+		ExpectedArray: []string{"1.12.0-beta.1", "1.12.0-beta.2", "v1.12.0-rc.1"},
+	},
+	{
+		PassedArray:   []string{"edge-21.12.1", "edge-21.11.4", "stable-2.11.0"},
+		ExpectedArray: []string{"stable-2.11.0", "edge-21.11.4", "edge-21.12.1"},
+	},
+	{
+		PassedArray:   []string{"istio-1.10.6", "istio-1.12.0", "0.0.0"},
+		ExpectedArray: []string{"0.0.0", "istio-1.10.6", "istio-1.12.0"},
+	},
+	{
+		PassedArray:   []string{"v1.0.0-rc.2", "v1.0.0-rc.1", "v0.11.0-rc.1"},
+		ExpectedArray: []string{"v0.11.0-rc.1", "v1.0.0-rc.1", "v1.0.0-rc.2"},
+	},
 }
 
 func TestSort(t *testing.T) {

--- a/utils/sortversions_test.go
+++ b/utils/sortversions_test.go
@@ -1,0 +1,57 @@
+package utils
+
+import "testing"
+
+type TestCases struct {
+	ExpectedArray []string
+	PassedArray   []string
+}
+
+var testcases = []TestCases{
+	{
+		PassedArray:   []string{"1.0.0", "0.5.6", "8.9.6"},
+		ExpectedArray: []string{"0.5.6", "1.0.0", "8.9.6"},
+	},
+	{
+		PassedArray:   []string{"v1.0.0", "0.5.6", "fasdfv8.9.6"},
+		ExpectedArray: []string{"0.5.6", "v1.0.0", "fasdfv8.9.6"},
+	},
+	{
+		PassedArray:   []string{"v1.0.0-alpha", "v1.0.0-alpha-beta", "v1.0.0-alpha-rc", "1.0.0-rc", "1.0.0"},
+		ExpectedArray: []string{"v1.0.0-alpha-beta", "v1.0.0-alpha-rc", "v1.0.0-alpha", "1.0.0-rc", "1.0.0"},
+	},
+	{
+		PassedArray:   []string{"v1.0.0.0", "1.0.0"},
+		ExpectedArray: []string{"v1.0.0.0", "1.0.0"},
+	},
+	{
+		PassedArray:   []string{"v1.0.0.0-alpha", "asffdsafgaga1.sag0.0######"},
+		ExpectedArray: []string{"v1.0.0.0-alpha", "asffdsafgaga1.sag0.0######"},
+	},
+	{
+		PassedArray:   []string{"1.0.0-alpha.beta", "1.0.0-alpha.1"},
+		ExpectedArray: []string{"1.0.0-alpha.beta", "1.0.0-alpha.1"},
+	},
+	{
+		PassedArray:   []string{"v1.0.0-stable", "0.9.8", "1.0.0-alpha.1", "v1.0.0-alpha"},
+		ExpectedArray: []string{"0.9.8", "1.0.0-alpha.1", "v1.0.0-alpha", "v1.0.0-stable"},
+	},
+}
+
+func TestSort(t *testing.T) {
+	for _, tc := range testcases {
+		SortDottedStringsByDigits(tc.PassedArray)
+		if !isEqual(tc.PassedArray, tc.ExpectedArray) {
+			t.Fatalf("Test Failed. Expected %+v Got %+v", tc.ExpectedArray, tc.PassedArray)
+		}
+	}
+}
+
+func isEqual(s1 []string, s2 []string) bool {
+	for i, s1 := range s1 {
+		if s1 != s2[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -189,7 +189,7 @@ func ReadLocalFile(location string) (string, error) {
 
 // Gets the latest stable release tag from github for a given org name and repo name(in that org)
 func GetLatestReleaseTag(org string, repo string) (string, error) {
-	var url string = "https://github.com/" + org + "/" + repo + "/releases/latest"
+	var url string = "https://github.com/" + org + "/" + repo + "/releases"
 	resp, err := http.Get(url)
 	if err != nil {
 		return "", ErrGettingLatestReleaseTag(err)
@@ -209,9 +209,14 @@ func GetLatestReleaseTag(org string, repo string) (string, error) {
 	if len(releases) == 0 {
 		return "", ErrGettingLatestReleaseTag(errors.New("no release found in this repository"))
 	}
-	latest := strings.ReplaceAll(releases[0], "/releases/tag/", "")
-	latest = strings.ReplaceAll(latest, "\"", "")
-	return latest, nil
+	var version []string
+	for _, rel := range releases {
+		latest := strings.ReplaceAll(rel, "/releases/tag/", "")
+		latest = strings.ReplaceAll(latest, "\"", "")
+		version = append(version, latest)
+	}
+	version = SortDottedStringsByDigits(version)
+	return version[len(version)-1], nil
 }
 
 // SafeClose is a helper function help to close the io

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -187,36 +187,36 @@ func ReadLocalFile(location string) (string, error) {
 	return string(data), nil
 }
 
-// Gets the latest stable release tag from github for a given org name and repo name(in that org)
-func GetLatestReleaseTag(org string, repo string) (string, error) {
+// Gets the latest stable release tags from github for a given org name and repo name(in that org) in sorted order
+func GetLatestReleaseTagsSorted(org string, repo string) ([]string, error) {
 	var url string = "https://github.com/" + org + "/" + repo + "/releases"
 	resp, err := http.Get(url)
 	if err != nil {
-		return "", ErrGettingLatestReleaseTag(err)
+		return nil, ErrGettingLatestReleaseTag(err)
 	}
 	defer safeClose(resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
-		return "", ErrGettingLatestReleaseTag(err)
+		return nil, ErrGettingLatestReleaseTag(err)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", ErrGettingLatestReleaseTag(err)
+		return nil, ErrGettingLatestReleaseTag(err)
 	}
 	re := regexp.MustCompile("/releases/tag/(.*?)\"")
 	releases := re.FindAllString(string(body), -1)
 	if len(releases) == 0 {
-		return "", ErrGettingLatestReleaseTag(errors.New("no release found in this repository"))
+		return nil, ErrGettingLatestReleaseTag(errors.New("no release found in this repository"))
 	}
-	var version []string
+	var versions []string
 	for _, rel := range releases {
 		latest := strings.ReplaceAll(rel, "/releases/tag/", "")
 		latest = strings.ReplaceAll(latest, "\"", "")
-		version = append(version, latest)
+		versions = append(versions, latest)
 	}
-	version = SortDottedStringsByDigits(version)
-	return version[len(version)-1], nil
+	versions = SortDottedStringsByDigits(versions)
+	return versions, nil
 }
 
 // SafeClose is a helper function help to close the io


### PR DESCRIPTION
Signed-off-by: ashish <ashishjaitiwari15112000@gmail.com>

**Description**

Across adapters as well as meshery server, a lot of times there comes the use case of sorting semantic versioning where we are not sure if the versions are normalized. This utility function does that
**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
