### PR TITLE
Preprocess Manifests and remove helm templating

### DIFF
--- a/utils/manifests/generateComponent.go
+++ b/utils/manifests/generateComponent.go
@@ -45,6 +45,7 @@ func GenerateComponents(manifest string, resource int, cfg Config) (*Component, 
 		return nil, err
 	}
 	path := filepath.Join(wd, "test.yaml")
+	removeMetadataFromCRD(&manifest)
 	err := populateTempyaml(manifest, path)
 	if err != nil {
 		return nil, err

--- a/utils/manifests/generateComponent.go
+++ b/utils/manifests/generateComponent.go
@@ -45,7 +45,7 @@ func GenerateComponents(manifest string, resource int, cfg Config) (*Component, 
 		return nil, err
 	}
 	path := filepath.Join(wd, "test.yaml")
-	removeMetadataFromCRD(&manifest)
+	removeHelmTemplatingFromCRD(&manifest)
 	err := populateTempyaml(manifest, path)
 	if err != nil {
 		return nil, err

--- a/utils/manifests/utils.go
+++ b/utils/manifests/utils.go
@@ -160,7 +160,7 @@ func populateTempyaml(yaml string, path string) error {
 }
 
 //removeMetadataFromCRD is used because in few cases (like linkerd), helm templating might be used there which makes the yaml invalid.
-//As we do not need metadata anyways in the filters required to generate components, we can remove this field entirely.
+//As those templates are useless for component creatin, we can replace them with "meshery" to make the YAML valid
 func removeMetadataFromCRD(crdyaml *string) {
 	y := strings.Split(*crdyaml, "\n---\n")
 	var yamlArr []string

--- a/utils/manifests/utils.go
+++ b/utils/manifests/utils.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/layer5io/meshkit/models/oam/core/v1alpha1"
-	"gopkg.in/yaml.v2"
 )
 
 var templateExpression *regexp.Regexp
@@ -171,15 +169,7 @@ func removeMetadataFromCRD(crdyaml *string) {
 			continue
 		}
 		y0 = templateExpression.ReplaceAllString(y0, "meshery")
-		var c map[string]interface{}
-		err := yaml.Unmarshal([]byte(y0), &c)
-		if err != nil {
-			fmt.Println("Error unmarshalling: ", err.Error())
-			return
-		}
-		delete(c, "metadata")
-		temp, _ := yaml.Marshal(c)
-		yamlArr = append(yamlArr, string(temp))
+		yamlArr = append(yamlArr, string(y0))
 	}
 	*crdyaml = strings.Join(yamlArr, "\n---\n")
 }

--- a/utils/manifests/utils.go
+++ b/utils/manifests/utils.go
@@ -161,7 +161,7 @@ func populateTempyaml(yaml string, path string) error {
 
 //removeMetadataFromCRD is used because in few cases (like linkerd), helm templating might be used there which makes the yaml invalid.
 //As those templates are useless for component creatin, we can replace them with "meshery" to make the YAML valid
-func removeMetadataFromCRD(crdyaml *string) {
+func removeHelmTemplatingFromCRD(crdyaml *string) {
 	y := strings.Split(*crdyaml, "\n---\n")
 	var yamlArr []string
 	for _, y0 := range y {


### PR DESCRIPTION
Signed-off-by: ashish <ashishjaitiwari15112000@gmail.com>

**Description**

Due to helm templating in linkerd CRDs, the yamls are marked as invalid. We do not want those templates. This PR preprocesses the manifests and replaces all instances of the template with "meshery". We would not need those templates anyways. 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
