### PR TITLE
adding output option for logger for golang testing in mesheryctl

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -54,8 +54,11 @@ func New(appname string, opts Options) (Handler, error) {
 
 	// log.SetReportCaller(true)
 	log.SetOutput(os.Stdout)
-	log.SetLevel(logrus.InfoLevel)
+	if opts.Output != nil {
+		log.SetOutput(opts.Output)
+	}
 
+	log.SetLevel(logrus.InfoLevel)
 	if opts.DebugLevel {
 		log.SetLevel(logrus.DebugLevel)
 	}

--- a/logger/types.go
+++ b/logger/types.go
@@ -1,5 +1,7 @@
 package logger
 
+import "io"
+
 const (
 	JsonLogFormat = iota
 	SyslogLogFormat
@@ -11,4 +13,5 @@ type Format int
 type Options struct {
 	Format     Format
 	DebugLevel bool
+	Output     io.Writer
 }


### PR DESCRIPTION
Signed-off-by: Piyush Singariya <piyushsingariya@gmail.com>

**Description**

This PR adds a new option for adding a custom output writer which will help in golang tests for mesheryctl where logs are captured via a string buffer.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
